### PR TITLE
Add development environment setup (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Agents
+
+## Cursor Cloud specific instructions
+
+### Product
+
+Fokus Launcher is a single-module Android launcher app (Kotlin + Jetpack Compose). There are no backend services, databases, or Docker containers to run — it is a purely client-side Android application.
+
+### Environment
+
+- **JDK 21** is required. `JAVA_HOME` must point to the JDK 21 installation (on Cloud VMs: `/usr/lib/jvm/java-21-openjdk-amd64`).
+- **Android SDK** must be installed at `$ANDROID_HOME` (`/home/ubuntu/android-sdk`) with packages: `platform-tools`, `platforms;android-36`, `build-tools;36.0.0`.
+- Both `JAVA_HOME` and `ANDROID_HOME`/`ANDROID_SDK_ROOT` are persisted in `~/.bashrc`.
+
+### Key commands
+
+See `README.md` § "Build From Source" and `.github/copilot-instructions.md` for full details. Quick reference:
+
+| Task | Command |
+|------|---------|
+| Build debug APK | `./gradlew :app:assembleDebug` |
+| Run unit tests | `./gradlew testDebugUnitTest` |
+| Run lint | `./gradlew lint` |
+| Run specific test | `./gradlew test --tests "com.lu4p.fokuslauncher.ui.home.HomeViewModelTest"` |
+
+### Caveats
+
+- **Gradle Daemon JVM**: `gradle/gradle-daemon-jvm.properties` specifies `toolchainVendor=JETBRAINS`. The Gradle wrapper auto-provisions a JetBrains JDK for the daemon on first run if one isn't present. This is expected and happens transparently.
+- **Lint pre-existing errors**: `./gradlew lint` reports ~91 `NewApi` errors that exist on `master`. These are pre-existing and not caused by agent changes. The CI workflow does **not** run lint — it only runs `testDebugUnitTest` and `assembleDebug`.
+- **No emulator/device needed for unit tests**: `testDebugUnitTest` uses Robolectric, so tests run on the JVM without an Android device or emulator.
+- **Configuration cache**: Gradle configuration cache is enabled (`gradle.properties`). Subsequent builds are significantly faster after the first run.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development environment instructions for the Fokus Launcher Android project.

### What's included

- Environment variables and SDK requirements (JDK 21, Android SDK with `platforms;android-36` and `build-tools;36.0.0`)
- Quick-reference table for key Gradle commands (build, test, lint)
- Caveats for Gradle daemon JVM toolchain auto-provisioning, pre-existing lint errors on `master`, Robolectric-based unit tests, and configuration cache

### Verification

All development tasks were verified on a fresh Cloud VM:

| Check | Command | Result |
|-------|---------|--------|
| Build | `./gradlew :app:assembleDebug` | BUILD SUCCESSFUL |
| Unit tests | `./gradlew testDebugUnitTest` | BUILD SUCCESSFUL (all pass) |
| Lint | `./gradlew lint` | 91 pre-existing `NewApi` errors (same as `master`) |

Build output:
[build_output.log](https://cursor.com/agents/bc-7d6b2e1a-f919-46c7-a0d2-40e5f1668166/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuild_output.log)

Test output:
[unit_test_output.log](https://cursor.com/agents/bc-7d6b2e1a-f919-46c7-a0d2-40e5f1668166/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Funit_test_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d6b2e1a-f919-46c7-a0d2-40e5f1668166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d6b2e1a-f919-46c7-a0d2-40e5f1668166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

