### PR TITLE
Fix dialer shortcut so it doesn't rely on dialer package name

### DIFF
--- a/app/src/main/java/com/lu4p/fokuslauncher/data/local/PreferencesManager.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/local/PreferencesManager.kt
@@ -119,7 +119,7 @@ class PreferencesManager @Inject constructor(@param:ApplicationContext private v
                         listOf(
                                 HomeShortcut(
                                         iconName = "call",
-                                        target = ShortcutTarget.App("com.google.android.dialer")
+                                        target = ShortcutTarget.DeepLink("tel:")
                                 )
                         )
                 prefs[RIGHT_SIDE_SHORTCUTS_KEY] = serializeRightSideShortcuts(defaultShortcuts)


### PR DESCRIPTION
On my phone running LineageOS 23.2, my dialer package is called com.android.dialer not com.google.android.dialer, so the call/dial icon does not work for me. This simple change uses a deep link that should open the default dialer app on any device.