### PR TITLE
feat(i18n): expose Basque, Finnish, Portuguese BR, Spanish in UI

### DIFF
--- a/app/src/main/java/com/lu4p/fokuslauncher/data/model/SystemCategoryKeys.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/model/SystemCategoryKeys.kt
@@ -17,7 +17,8 @@ object SystemCategoryKeys {
     const val SOCIAL = "Social"
     const val MEDIA = "Media"
 
-    private val supportedLocaleTags = listOf("en", "de", "pl", "ru", "zh-CN", "tr", "da")
+    private val supportedLocaleTags =
+            listOf("en", "de", "pl", "ru", "zh-CN", "tr", "da", "es", "eu", "fi", "pt-BR")
 
     private data class CategoryDef(
         val key: String,

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/SettingsScreen.kt
@@ -1035,7 +1035,10 @@ private fun AppLanguageDropdown(
         onTagSelected: (String) -> Unit
 ) {
     val systemDefaultLabel = stringResource(R.string.settings_language_system_default)
-    val supportedLocaleTags = remember { listOf("en", "de", "pl", "ru", "zh-CN", "tr", "da") }
+    val supportedLocaleTags =
+            remember {
+                listOf("en", "de", "pl", "ru", "zh-CN", "tr", "da", "es", "eu", "fi", "pt-BR")
+            }
     val options =
             remember(systemDefaultLabel) {
                 val collator = Collator.getInstance(Locale.ROOT).apply { strength = Collator.PRIMARY }

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -3,7 +3,11 @@
     <locale android:name="da"/>
     <locale android:name="en" />
     <locale android:name="de" />
+    <locale android:name="es" />
+    <locale android:name="eu" />
+    <locale android:name="fi" />
     <locale android:name="pl" />
+    <locale android:name="pt-BR" />
     <locale android:name="ru"/>
     <locale android:name="zh"/>
     <locale android:name="tr"/>


### PR DESCRIPTION
Add locale tags to the settings language list, locales_config for per-app language, and system-category label matching.