### PR TITLE
Fix/issue 94 double tap lock fix

### DIFF
--- a/app/src/androidTest/java/com/lu4p/fokuslauncher/ui/home/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/lu4p/fokuslauncher/ui/home/HomeScreenTest.kt
@@ -5,13 +5,16 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.doubleClick
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
 import com.lu4p.fokuslauncher.data.model.FavoriteApp
 import com.lu4p.fokuslauncher.data.model.HomeShortcut
 import com.lu4p.fokuslauncher.data.model.WeatherData
 import com.lu4p.fokuslauncher.ui.theme.FokusLauncherTheme
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -310,5 +313,81 @@ class HomeScreenTest {
                         .boundsInRoot.bottom
 
         assertTrue(bottomShortcut >= bottomFavorite - 1f)
+    }
+
+    @Test
+    fun homeScreen_doubleTapToLock_triggersCallback() {
+        var doubleTapTriggered = false
+        composeTestRule.setContent {
+            FokusLauncherTheme {
+                HomeScreenContent(
+                        uiState = HomeUiState(doubleTapEmptyLockEnabled = true),
+                        clockUiState = clock(),
+                        weatherUiState = weatherOff,
+                        favorites = testFavorites,
+                        rightSideShortcuts = testRightSideShortcuts,
+                        onLabelClick = {},
+                        onLabelLongPress = {},
+                        onIconClick = {},
+                        onDoubleTapEmptyLock = { doubleTapTriggered = true }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("home_screen").performTouchInput {
+            doubleClick()
+        }
+        assertTrue(doubleTapTriggered)
+    }
+
+    @Test
+    fun homeScreen_doubleTapToLockDisabled_doesNotTriggerCallback() {
+        var doubleTapTriggered = false
+        composeTestRule.setContent {
+            FokusLauncherTheme {
+                HomeScreenContent(
+                        uiState = HomeUiState(doubleTapEmptyLockEnabled = false),
+                        clockUiState = clock(),
+                        weatherUiState = weatherOff,
+                        favorites = testFavorites,
+                        rightSideShortcuts = testRightSideShortcuts,
+                        onLabelClick = {},
+                        onLabelLongPress = {},
+                        onIconClick = {},
+                        onDoubleTapEmptyLock = { doubleTapTriggered = true }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("home_screen").performTouchInput {
+            doubleClick()
+        }
+        assertFalse(doubleTapTriggered)
+    }
+
+    @Test
+    fun homeScreen_doubleTapOnFavorite_doesNotTriggerLock() {
+        var doubleTapTriggered = false
+        composeTestRule.setContent {
+            FokusLauncherTheme {
+                HomeScreenContent(
+                        uiState = HomeUiState(doubleTapEmptyLockEnabled = true),
+                        clockUiState = clock(),
+                        weatherUiState = weatherOff,
+                        favorites = testFavorites,
+                        rightSideShortcuts = testRightSideShortcuts,
+                        onLabelClick = {},
+                        onLabelLongPress = {},
+                        onIconClick = {},
+                        onDoubleTapEmptyLock = { doubleTapTriggered = true }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Music").performTouchInput {
+            doubleClick()
+        }
+
+        assertFalse("Double tap should not be triggered on favorite", doubleTapTriggered)
     }
 }

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeScreen.kt
@@ -215,7 +215,13 @@ fun HomeScreenContent(
                 indication = null,
                 interactionSource = noIndication,
                 onClick = { },
-                onLongClick = onHomeScreenLongPress
+                onLongClick = onHomeScreenLongPress,
+                onDoubleClick = if (doubleTapEmptyLockEnabled) {
+                    {
+                        play()
+                        onDoubleTapEmptyLock()
+                    }
+                } else null
             )
             .testTag("home_screen")
     ) {
@@ -238,27 +244,7 @@ fun HomeScreenContent(
                 outlined = uiState.usesPhotoWallpaper,
             )
 
-            // Push favorites to the bottom; optional double-tap to lock on this empty band
-            if (doubleTapEmptyLockEnabled) {
-                val emptyTapSource = remember { MutableInteractionSource() }
-                Box(
-                        modifier =
-                                Modifier.weight(1f)
-                                        .fillMaxWidth()
-                                        .combinedClickable(
-                                                indication = null,
-                                                interactionSource = emptyTapSource,
-                                                onClick = {},
-                                                onLongClick = onHomeScreenLongPress,
-                                                onDoubleClick = {
-                                                    play()
-                                                    onDoubleTapEmptyLock()
-                                                },
-                                        )
-                )
-            } else {
-                Spacer(modifier = Modifier.weight(1f))
-            }
+            Spacer(modifier = Modifier.weight(1f))
 
             HomeFavoritesSection(
                 homeAlignment = uiState.homeAlignment,

--- a/app/src/test/java/com/lu4p/fokuslauncher/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/lu4p/fokuslauncher/ui/home/HomeViewModelTest.kt
@@ -25,10 +25,13 @@ import com.lu4p.fokuslauncher.data.model.appMetadataKey
 import com.lu4p.fokuslauncher.data.repository.AppRepository
 import com.lu4p.fokuslauncher.data.repository.RemovedApp
 import com.lu4p.fokuslauncher.data.repository.WeatherRepository
+import com.lu4p.fokuslauncher.utils.LockScreenHelper
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -654,5 +657,20 @@ class HomeViewModelTest {
         viewModel.launchShortcut(HomeShortcut(target = ShortcutTarget.App("com.lu4p.music")))
 
         verify { appRepository.launchApp("com.lu4p.music") }
+    }
+
+    @Test
+    fun `onDoubleTapEmptyLock calls lockScreenIfPossible when enabled`() {
+        mockkObject(LockScreenHelper)
+        every { LockScreenHelper.isLockAccessibilityServiceEnabled(any()) } returns true
+        every { LockScreenHelper.lockScreenIfPossible() } returns true
+        every { preferencesManager.doubleTapEmptyLockFlow } returns flowOf(true)
+
+        val viewModel = createViewModel()
+        viewModel.onDoubleTapEmptyLock()
+        testDispatcher.scheduler.runCurrent()
+
+        verify { LockScreenHelper.lockScreenIfPossible() }
+        unmockkObject(LockScreenHelper)
     }
 }


### PR DESCRIPTION
### Fix: Double-tap to lock not working outside central area
https://github.com/luantak/FokusLauncher/issues/94

Issue:  
Double-tap to lock was only working within a specific central region. Taps on margins, padding, or gaps between widgets were ignored.

Root cause:  
Gesture listener was attached to a limited view instead of the full root container.

Fix:  
Moved the double-tap gesture listener to the root container view.  
This enables detection across all non-interactive areas while preserving widget/icon interactions.

Behavior after fix:
- Double-tap works on empty areas across the screen
- Widgets and icons continue to handle their own touch events
- No interference with click/scroll behavior (observed)

Tested on:
- Environment: Android Emulator
- API level: [37]
- Device profile: [Pixel 9a]

Scenarios tested:
- Empty area → lock triggered
- App icon → opens normally
- Widget → interaction unaffected

Limitations:
- Not yet validated on a physical device (touch latency and gesture detection may differ)

Notes:
If any views consume touch events unexpectedly, additional handling may be required.