### PR TITLE
Accept pinned PWA shortcuts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -65,6 +65,16 @@
         </provider>
 
         <activity
+            android:name=".ConfirmPinShortcutActivity"
+            android:exported="true"
+            android:theme="@style/Theme.FokusLauncher">
+            <intent-filter>
+                <action android:name="android.content.pm.action.CONFIRM_PIN_SHORTCUT" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
+        <activity
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTask"

--- a/app/src/main/java/com/lu4p/fokuslauncher/ConfirmPinShortcutActivity.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ConfirmPinShortcutActivity.kt
@@ -1,0 +1,38 @@
+package com.lu4p.fokuslauncher
+
+import android.app.Activity
+import android.content.Intent
+import android.content.pm.LauncherApps
+import android.os.Build
+import android.os.Bundle
+
+/**
+ * Accepts browser PWA/shortcut pin requests so browsers expose "Add to Home screen" while Fokus
+ * is the default launcher. The pinned shortcut is stored by Android's launcher service and picked
+ * up by AppRepository through LauncherApps pinned shortcuts.
+ */
+class ConfirmPinShortcutActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        if (intent?.action == LauncherApps.ACTION_CONFIRM_PIN_SHORTCUT) {
+            val request = intent?.pinItemRequest()
+            if (request?.requestType == LauncherApps.PinItemRequest.REQUEST_TYPE_SHORTCUT) {
+                request.accept()
+            }
+        }
+
+        finish()
+    }
+
+    @Suppress("DEPRECATION")
+    private fun Intent.pinItemRequest(): LauncherApps.PinItemRequest? =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                getParcelableExtra(
+                        LauncherApps.EXTRA_PIN_ITEM_REQUEST,
+                        LauncherApps.PinItemRequest::class.java,
+                )
+            } else {
+                getParcelableExtra(LauncherApps.EXTRA_PIN_ITEM_REQUEST)
+            }
+}


### PR DESCRIPTION
This registers a confirmation activity for Android pinned shortcut requests and accepts browser-created shortcut pins when Fokus is the default launcher. Android stores the accepted shortcut with the launcher service, so the existing pinned-shortcut loading path can pick up PWA shortcuts without adding a separate persistence layer.