### PR TITLE
Add middle home alignment option

### DIFF
--- a/app/src/main/java/com/lu4p/fokuslauncher/data/model/HomeAlignment.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/model/HomeAlignment.kt
@@ -8,12 +8,14 @@ import com.lu4p.fokuslauncher.R
  * on the home screen.
  *
  * - [LEFT]: Labels on the left, shortcut icons on the right (default).
- * - [CENTER]: Labels and shortcut icons centered together.
+ * - [CENTER]: Labels and shortcut icons horizontally centered together near the bottom.
+ * - [MIDDLE]: Labels and shortcut icons horizontally centered in the middle of the screen.
  * - [RIGHT]: Labels on the right, shortcut icons on the left (swapped).
  */
 enum class HomeAlignment(@param:StringRes val labelRes: Int) {
     LEFT(R.string.home_alignment_left),
     CENTER(R.string.home_alignment_center),
+    MIDDLE(R.string.home_alignment_middle),
     RIGHT(R.string.home_alignment_right);
 
     companion object {

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeScreen.kt
@@ -282,7 +282,11 @@ fun HomeScreenContent(
                 onIconClick = onIconClick
             )
 
-            Spacer(modifier = Modifier.height(4.dp))
+            if (uiState.homeAlignment == HomeAlignment.MIDDLE) {
+                Spacer(modifier = Modifier.weight(1f))
+            } else {
+                Spacer(modifier = Modifier.height(4.dp))
+            }
         }
 
         HomeDefaultLauncherBanner(
@@ -493,7 +497,7 @@ private fun HomeFavoritesSection(
     val listModifier =
         Modifier.fillMaxWidth().testTag("favorites_list")
     when (homeAlignment) {
-        HomeAlignment.CENTER ->
+        HomeAlignment.CENTER, HomeAlignment.MIDDLE ->
             Column(
                 modifier = listModifier,
                 horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,6 +119,7 @@
     <string name="home_alignment_subtitle">Position of app labels and shortcut icons</string>
     <string name="home_alignment_left">Left</string>
     <string name="home_alignment_center">Center</string>
+    <string name="home_alignment_middle">Middle</string>
     <string name="home_alignment_right">Right</string>
 
     <!-- Edit home / shortcuts screens -->


### PR DESCRIPTION
Adds a new Middle home alignment option for the home screen. This keeps the existing centered layout for labels and shortcut icons, but balances the vertical spacing below the favorites so the group sits around the middle of the screen instead of staying pinned near the bottom.

Validation:
- `./gradlew :app:compileDebugKotlin --no-daemon` could not run locally because the Android SDK is not configured in this environment (`SDK location not found`).