### PR TITLE
feat: Add settings toggle to auto-open keyboard in app drawer

### DIFF
--- a/app/src/main/java/com/lu4p/fokuslauncher/data/local/PreferencesManager.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/local/PreferencesManager.kt
@@ -114,6 +114,8 @@ class PreferencesManager @Inject constructor(@param:ApplicationContext private v
          */
         private val DRAWER_SEARCH_AUTO_LAUNCH_KEY =
                 booleanPreferencesKey("drawer_search_auto_launch")
+        private val DRAWER_AUTO_OPEN_KEYBOARD_KEY =
+                booleanPreferencesKey("drawer_auto_open_keyboard")
         private val DRAWER_SCROLL_TO_TOP_AUTO_KEYBOARD_KEY =
                 booleanPreferencesKey("drawer_scroll_to_top_auto_keyboard")
         private val HAS_COMPLETED_ONBOARDING_KEY = booleanPreferencesKey("has_completed_onboarding")
@@ -538,6 +540,11 @@ class PreferencesManager @Inject constructor(@param:ApplicationContext private v
             prefFlow(DRAWER_SEARCH_AUTO_LAUNCH_KEY, true)
     suspend fun setDrawerSearchAutoLaunch(enabled: Boolean) =
             setPref(DRAWER_SEARCH_AUTO_LAUNCH_KEY, enabled)
+
+    val drawerAutoOpenKeyboardFlow: Flow<Boolean> =
+            prefFlow(DRAWER_AUTO_OPEN_KEYBOARD_KEY, true)
+    suspend fun setDrawerAutoOpenKeyboard(enabled: Boolean) =
+            setPref(DRAWER_AUTO_OPEN_KEYBOARD_KEY, enabled)
 
     val drawerScrollToTopAutoKeyboardFlow: Flow<Boolean> =
             prefFlow(DRAWER_SCROLL_TO_TOP_AUTO_KEYBOARD_KEY, false)

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/drawer/AppDrawerScreen.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/drawer/AppDrawerScreen.kt
@@ -811,7 +811,7 @@ fun AppDrawerContent(
     val listState = rememberLazyListState()
     val latestCategories = rememberUpdatedState(uiState.categories)
     val latestSelectedCategory = rememberUpdatedState(uiState.selectedCategory)
-    var showSearch by remember { mutableStateOf(false) }
+    var showSearch by remember { mutableStateOf(uiState.drawerAutoOpenKeyboard) }
 
     LaunchedEffect(uiState.selectedCategory) { listState.scrollToItem(0) }
 
@@ -881,14 +881,18 @@ fun AppDrawerContent(
             isAtTop,
             showSearch,
             useSidebarCategoryDrawer,
+            uiState.drawerAutoOpenKeyboard,
             uiState.drawerScrollToTopAutoKeyboard,
             drawerSettling,
     ) {
+        if (useSidebarCategoryDrawer && isAtTop && hasScrolledDown && uiState.drawerScrollToTopAutoKeyboard) {
+            showSearch = true
+        }
         val shouldFocusSearch =
                 if (useSidebarCategoryDrawer) {
                     showSearch && isAtTop
                 } else {
-                    isAtTop && (!hasScrolledDown || uiState.drawerScrollToTopAutoKeyboard)
+                    isAtTop && ((!hasScrolledDown && uiState.drawerAutoOpenKeyboard) || uiState.drawerScrollToTopAutoKeyboard)
                 }
         // Chip layout: wait for drawer settle so scrollToItem(0) does not block opening keyboard.
         val readyToFocus = shouldFocusSearch && (!drawerSettling || useSidebarCategoryDrawer)
@@ -910,7 +914,10 @@ fun AppDrawerContent(
             override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
                 if (source == NestedScrollSource.UserInput && available.y > 0 && !listState.canScrollBackward) {
                     // Immediate response for pull-down gesture at the boundary
-                    if (uiState.drawerScrollToTopAutoKeyboard && !useSidebarCategoryDrawer) {
+                    if (uiState.drawerScrollToTopAutoKeyboard) {
+                        if (useSidebarCategoryDrawer) {
+                            showSearch = true
+                        }
                         // LaunchedEffect(isAtTop) handles focus when scrolling to top; re-request
                         // if already at top and pulling down at the list boundary.
                         focusRequester.requestFocus()

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/drawer/AppDrawerViewModel.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/drawer/AppDrawerViewModel.kt
@@ -82,6 +82,8 @@ data class AppDrawerUiState(
         val categoryDrawerIconOverrides: Map<String, String> = emptyMap(),
         val usesPhotoWallpaper: Boolean = false,
         val drawerAppSortMode: DrawerAppSortMode = DrawerAppSortMode.ALPHABETICAL,
+        /** Automatically open keyboard when app drawer is opened. */
+        val drawerAutoOpenKeyboard: Boolean = true,
         /** Automatically open keyboard when scrolling to the top of the app drawer. */
         val drawerScrollToTopAutoKeyboard: Boolean = false,
         /**
@@ -303,6 +305,7 @@ constructor(
         observeDrawerCategoryRailAndIcons()
         observeDrawerSortOpenCountsAndCustomOrder()
         observeDrawerDotSearchPreferences()
+        observeDrawerAutoOpenKeyboard()
         observeDrawerScrollToTopAutoKeyboard()
         observeProfileDisplayNameOverrides()
         observeLauncherAppearance()
@@ -336,6 +339,14 @@ constructor(
         viewModelScope.launch {
             preferencesManager.drawerSearchAutoLaunchFlow.collect { enabled ->
                 drawerSearchAutoLaunchEnabled = enabled
+            }
+        }
+    }
+
+    private fun observeDrawerAutoOpenKeyboard() {
+        viewModelScope.launch {
+            preferencesManager.drawerAutoOpenKeyboardFlow.collect { enabled ->
+                _uiState.update { it.copy(drawerAutoOpenKeyboard = enabled) }
             }
         }
     }

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/SettingsScreen.kt
@@ -561,15 +561,21 @@ private fun SettingsScreenContent(
                     onCheckedChange = viewModel::setDrawerSearchAutoLaunch
             )
         }
-        if (!uiState.drawerSidebarCategories) {
-            item {
-                SettingsToggleRow(
-                        label = stringResource(R.string.settings_drawer_scroll_to_top_auto_keyboard),
-                        subtitle = stringResource(R.string.settings_drawer_scroll_to_top_auto_keyboard_subtitle),
-                        checked = uiState.drawerScrollToTopAutoKeyboard,
-                        onCheckedChange = viewModel::setDrawerScrollToTopAutoKeyboard
-                )
-            }
+        item {
+            SettingsToggleRow(
+                    label = stringResource(R.string.settings_drawer_auto_open_keyboard),
+                    subtitle = stringResource(R.string.settings_drawer_auto_open_keyboard_subtitle),
+                    checked = uiState.drawerAutoOpenKeyboard,
+                    onCheckedChange = viewModel::setDrawerAutoOpenKeyboard
+            )
+        }
+        item {
+            SettingsToggleRow(
+                    label = stringResource(R.string.settings_drawer_scroll_to_top_auto_keyboard),
+                    subtitle = stringResource(R.string.settings_drawer_scroll_to_top_auto_keyboard_subtitle),
+                    checked = uiState.drawerScrollToTopAutoKeyboard,
+                    onCheckedChange = viewModel::setDrawerScrollToTopAutoKeyboard
+            )
         }
         item {
             SettingsToggleRow(

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/SettingsViewModel.kt
@@ -82,6 +82,8 @@ data class SettingsUiState(
         val drawerSidebarCategories: Boolean = false,
         /** Launch the app when search narrows to a single match (drawer search). */
         val drawerSearchAutoLaunch: Boolean = true,
+        /** Auto-launch keyboard when opening the app drawer. */
+        val drawerAutoOpenKeyboard: Boolean = true,
         /** Auto-launch keyboard when scrolling to the top of the app drawer. */
         val drawerScrollToTopAutoKeyboard: Boolean = false,
         /** When true, category rail is on the left; default false places it on the right. */
@@ -245,8 +247,9 @@ constructor(
                                     preferencesManager.drawerSidebarCategoriesFlow,
                                     preferencesManager.drawerAppSortModeFlow,
                                     preferencesManager.drawerSearchAutoLaunchFlow,
+                                    preferencesManager.drawerAutoOpenKeyboardFlow,
                                     preferencesManager.drawerScrollToTopAutoKeyboardFlow,
-                            ) { sidebarCategories, sortMode, searchAutoLaunch, scrollToTopAutoKeyboard ->
+                            ) { sidebarCategories, sortMode, searchAutoLaunch, autoOpenKeyboard, scrollToTopAutoKeyboard ->
                                 DrawerPrefs(
                                         swipeRightTarget = null, // placeholder
                                         preferredWeatherAppPackage = "", // placeholder
@@ -254,6 +257,7 @@ constructor(
                                         drawerSidebarCategories = sidebarCategories,
                                         drawerAppSortMode = sortMode,
                                         drawerSearchAutoLaunch = searchAutoLaunch,
+                                        drawerAutoOpenKeyboard = autoOpenKeyboard,
                                         drawerScrollToTopAutoKeyboard = scrollToTopAutoKeyboard,
                                 )
                             },
@@ -399,6 +403,7 @@ constructor(
                         temperatureUnit = homeWidgetItems.temperatureUnit,
                         drawerSidebarCategories = drawer.drawerSidebarCategories,
                         drawerSearchAutoLaunch = drawer.drawerSearchAutoLaunch,
+                        drawerAutoOpenKeyboard = drawer.drawerAutoOpenKeyboard,
                         drawerScrollToTopAutoKeyboard = drawer.drawerScrollToTopAutoKeyboard,
                         drawerCategorySidebarOnLeft = lockRail.drawerCategorySidebarOnLeft,
                         categoryDrawerIconOverrides = lockRail.categoryDrawerIconOverrides,
@@ -462,6 +467,7 @@ constructor(
             val drawerSidebarCategories: Boolean,
             val drawerAppSortMode: DrawerAppSortMode,
             val drawerSearchAutoLaunch: Boolean,
+            val drawerAutoOpenKeyboard: Boolean,
             val drawerScrollToTopAutoKeyboard: Boolean,
     )
 
@@ -740,6 +746,9 @@ constructor(
 
     fun setDrawerSearchAutoLaunch(enabled: Boolean) =
             launchPreferences { setDrawerSearchAutoLaunch(enabled) }
+
+    fun setDrawerAutoOpenKeyboard(enabled: Boolean) =
+            launchPreferences { setDrawerAutoOpenKeyboard(enabled) }
 
     fun setDrawerScrollToTopAutoKeyboard(enabled: Boolean) =
             launchPreferences { setDrawerScrollToTopAutoKeyboard(enabled) }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -374,6 +374,8 @@
     <string name="settings_matrix_subtitle">Get help and share feedback</string>
 
     <!-- Settings - App drawer -->
+    <string name="settings_drawer_auto_open_keyboard">Auto open keyboard</string>
+    <string name="settings_drawer_auto_open_keyboard_subtitle">Automatically open keyboard and search when opening the app drawer</string>
     <string name="settings_drawer_scroll_to_top_auto_keyboard">Keyboard on scroll to top</string>
     <string name="settings_drawer_scroll_to_top_auto_keyboard_subtitle">Automatically open keyboard and search when scrolling to the top of the app list</string>
 </resources>


### PR DESCRIPTION
This Pull Request makes the **Auto-Open Keyboard** setting universally available and functional across all app drawer layouts, including the Sidebar Category view. 

Previously, the keyboard auto-open setting was hidden and ignored when `drawerSidebarCategories` (sidebar category layout) was enabled. This change ensures that users can toggle and use the auto-open keyboard functionality regardless of their preferred drawer layout.

## Changes Introduced

* **Settings Visibility**: Removed the layout constraint in [SettingsScreen.kt](file:///app/src/main/java/com/lu4p/fokuslauncher/ui/settings/SettingsScreen.kt) that hid the keyboard auto-open setting when the sidebar category drawer was enabled.
* **Sidebar Mode Support**: Updated [AppDrawerScreen.kt](file:///app/src/main/java/com/lu4p/fokuslauncher/ui/drawer/AppDrawerScreen.kt) to initialize the search bar visibility and focus state based on the user's `drawerAutoOpenKeyboard` preference when the drawer is in category sidebar mode.
* **Scroll-to-Top Compatibility**: Fixed the "scroll to top to open keyboard" feature to correctly trigger and focus the keyboard when scrolling back to the top of the app list in sidebar mode.
* **Clean Configuration**: Ensured state variables (`drawerAutoOpenKeyboard`) and local storage keys are fully wired through [PreferencesManager.kt](file:///app/src/main/java/com/lu4p/fokuslauncher/data/local/PreferencesManager.kt), [SettingsViewModel.kt](file:///app/src/main/java/com/lu4p/fokuslauncher/ui/settings/SettingsViewModel.kt), and [AppDrawerViewModel.kt](file:///app/src/main/java/com/lu4p/fokuslauncher/ui/drawer/AppDrawerViewModel.kt).

## How to Test

1. Open **Settings** -> **App Drawer Settings**.
2. Verify that **Auto-open keyboard** is visible and toggleable even when using the Sidebar Category layout.
3. Enable **Auto-open keyboard**, open the app drawer, and confirm that the search bar appears and the keyboard is automatically requested.
4. Test the **Scroll to top to open keyboard** setting in sidebar mode to ensure the keyboard is summoned correctly when scrolling up.