### PR TITLE
Add Gold visual style option

### DIFF
--- a/app/src/main/java/com/lu4p/fokuslauncher/data/model/LauncherVisualStyle.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/model/LauncherVisualStyle.kt
@@ -8,6 +8,7 @@ enum class LauncherVisualStyle(@param:StringRes val labelRes: Int) {
     CLASSIC(R.string.visual_style_classic),
     NEON_MAGENTA(R.string.visual_style_neon_magenta),
     NEON_LIME(R.string.visual_style_neon_lime),
+    GOLD(R.string.visual_style_gold),
     NEON_AMBER(R.string.visual_style_neon_amber),
     NEON_PINK(R.string.visual_style_neon_pink),
     LAVENDER(R.string.visual_style_lavender),

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/theme/VisualStyleColors.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/theme/VisualStyleColors.kt
@@ -13,6 +13,8 @@ fun LauncherVisualStyle.neonPalette(): NeonPalette? =
                     NeonPalette(primary = Color(0xFFE070FF), muted = Color(0xFFB092D0))
             LauncherVisualStyle.NEON_LIME ->
                     NeonPalette(primary = Color(0xFF58FF7A), muted = Color(0xFF78C892))
+            LauncherVisualStyle.GOLD ->
+                    NeonPalette(primary = Color(0xFFFFD700), muted = Color(0xFFFFC125))
             LauncherVisualStyle.NEON_AMBER ->
                     NeonPalette(primary = Color(0xFFFF8F70), muted = Color(0xFFD9A894))
             LauncherVisualStyle.NEON_PINK ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -304,6 +304,7 @@
     <string name="visual_style_classic">Classic</string>
     <string name="visual_style_neon_magenta">Cosmic Violet</string>
     <string name="visual_style_neon_lime">Terminal Green</string>
+    <string name="visual_style_gold">Gold</string>
     <string name="visual_style_neon_amber">Coral</string>
     <string name="visual_style_neon_pink">Hot Pink</string>
     <string name="visual_style_lavender">Lavender</string>


### PR DESCRIPTION
## Summary

Adds a new **Gold** accent to the visual style presets, sitting right after the existing Terminal Green in the picker.

- Primary accent: bright metallic gold `#FFD700`
- Muted/secondary: deeper gold `#FFC125`

## Changes

- `LauncherVisualStyle.kt` — new `GOLD` enum value
- `VisualStyleColors.kt` — gold `NeonPalette` (primary + muted)
- `strings.xml` — new `visual_style_gold` label ("Gold")

The picker iterates `LauncherVisualStyle.entries`, so the option appears automatically with no further wiring.

## Testing

Built a debug APK and installed on a physical device; selected the new **Gold** style and confirmed home screen text, app drawer, and icon accents render in the gold tone alongside the other presets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)