### PR TITLE
Fix home favorites re-seeding to defaults when cleared

### DIFF
--- a/app/src/main/java/com/lu4p/fokuslauncher/data/local/PreferencesManager.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/local/PreferencesManager.kt
@@ -65,6 +65,8 @@ class PreferencesManager @Inject constructor(@param:ApplicationContext private v
 
     companion object {
         private val FAVORITES_KEY = stringPreferencesKey("favorite_apps")
+        /** Written when the user clears all favorites so the key survives (see [setFavorites]). */
+        private const val FAVORITES_EMPTY_MARKER = "__empty__"
         private val SWIPE_LEFT_KEY = stringPreferencesKey("swipe_left_app")
         private val SWIPE_RIGHT_KEY = stringPreferencesKey("swipe_right_app")
         private val RIGHT_SIDE_SHORTCUTS_KEY = stringPreferencesKey("right_side_shortcuts")
@@ -186,9 +188,16 @@ class PreferencesManager @Inject constructor(@param:ApplicationContext private v
 
     suspend fun setFavorites(favorites: List<FavoriteApp>) {
         context.fokusLauncherPreferencesDataStore.edit { prefs ->
+            // Store a non-empty marker when the user clears all favorites: some DataStore backends
+            // omit empty strings, which would drop the key and re-seed [DEFAULT_FAVORITES]. This
+            // mirrors [RIGHT_SIDE_SHORTCUTS_EMPTY_MARKER].
             prefs[FAVORITES_KEY] =
-                    favorites.joinToString("|") {
-                        "${it.label};${it.packageName};${it.iconName};${it.iconPackage};${it.profileKey}"
+                    if (favorites.isEmpty()) {
+                        FAVORITES_EMPTY_MARKER
+                    } else {
+                        favorites.joinToString("|") {
+                            "${it.label};${it.packageName};${it.iconName};${it.iconPackage};${it.profileKey}"
+                        }
                     }
         }
     }
@@ -829,7 +838,7 @@ class PreferencesManager @Inject constructor(@param:ApplicationContext private v
     // --- Parsing ---
 
     private fun parseFavorites(raw: String): List<FavoriteApp> {
-        if (raw.isBlank()) return emptyList()
+        if (raw.isBlank() || raw == FAVORITES_EMPTY_MARKER) return emptyList()
         return raw.split("|").mapNotNull { entry ->
             // New format: "label;packageName;iconName;iconPackage"
             val semiParts = entry.split(";")

--- a/app/src/test/java/com/lu4p/fokuslauncher/data/local/PreferencesManagerTest.kt
+++ b/app/src/test/java/com/lu4p/fokuslauncher/data/local/PreferencesManagerTest.kt
@@ -56,6 +56,13 @@ class PreferencesManagerTest {
     }
 
     @Test
+    fun `parseFavorites treats empty marker as no favorites`() {
+        // The marker is persisted in place of an empty string so the key is not dropped and
+        // DEFAULT_FAVORITES is not re-seeded when the user clears all favorites.
+        assertEquals(0, parseFavorites("__empty__").size)
+    }
+
+    @Test
     fun `parseFavorites handles single entry new format`() {
         val raw = "Music;com.lu4p.music;star"
         val result = parseFavorites(raw)


### PR DESCRIPTION
## Summary

Clearing home-screen favorites down to empty caused the **demo default favorites to reappear**, making some items effectively unremovable — most visibly the phone-sentinel "Health" favorite from `DEFAULT_FAVORITES`.

## Root cause

`setFavorites` serialized an empty list to an **empty string**. Some DataStore backends omit empty-string values, which drops the `favorite_apps` key entirely. The favorites flow then falls back to `DEFAULT_FAVORITES` via `prefs[FAVORITES_KEY] ?: DEFAULT_FAVORITES`, re-seeding the whole demo set. Because the phone-sentinel favorite is always preserved during installed-app pruning, it tends to be the last favorite remaining, so removing it repeatedly re-triggers the reseed and it never goes away.

This is the same failure mode the right-side shortcuts already guard against with `RIGHT_SIDE_SHORTCUTS_EMPTY_MARKER`; favorites just never got the same treatment.

## Fix

- Persist a non-empty `__empty__` marker when the favorites list is cleared, so the key survives.
- Treat that marker as "no favorites" on read in `parseFavorites`.
- Add a unit test covering the marker.

## Testing

`PreferencesManagerTest` passes (including the new case). Verified on a device: removing all favorites (including the "Health" entry) now sticks across relaunch instead of re-seeding the defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)