### PR TITLE
Enforce HTTPS app-wide via network security config

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:localeConfig="@xml/locales_config"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         tools:targetApi="36"
         android:supportsRtl="true"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Disallow cleartext (HTTP) traffic app-wide; all network use (e.g. weather) is HTTPS. -->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
+</network-security-config>


### PR DESCRIPTION
## Summary

Adds a network security config that disallows cleartext (HTTP) traffic app-wide, so the launcher never sends an unencrypted request.

- New `res/xml/network_security_config.xml` with `cleartextTrafficPermitted="false"`.
- Referenced from `<application android:networkSecurityConfig=...>` in the manifest.

## Why

Defense-in-depth. All current network use — the weather widget's Open-Meteo request — is already HTTPS, so there is **no functional change**; this just makes the guarantee explicit and enforced by the platform (a future cleartext URL would fail fast rather than silently send in the clear). Supported since API 24, so it covers the full `minSdk 26` range.

## Testing

`assembleDebug` builds cleanly; no source uses `http://`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)