### PR TITLE
Display upcoming alarm under the home clock

### DIFF
--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeScreen.kt
@@ -423,13 +423,49 @@ private fun HomeClockWeatherHeader(
                                     .offset(y = screenTimeTop),
             )
         }
-        ClockWidget(
-                time = clockUiState.currentTime,
-                is24HourFormat = clockUiState.is24HourFormat,
-                outlined = outlined,
-                onClick = onClockClick,
-                modifier = Modifier.align(Alignment.TopStart).testTag("clock_widget"),
-        )
+        Column(
+                modifier = Modifier.align(Alignment.TopStart),
+        ) {
+            ClockWidget(
+                    time = clockUiState.currentTime,
+                    is24HourFormat = clockUiState.is24HourFormat,
+                    outlined = outlined,
+                    onClick = onClockClick,
+                    modifier = Modifier.testTag("clock_widget"),
+            )
+            clockUiState.nextAlarm?.let { alarm ->
+                Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier =
+                                Modifier.padding(top = 4.dp)
+                                        .clickableNoRippleWithSystemSound(onClick = onClockClick)
+                                        .testTag("next_alarm_widget"),
+                ) {
+                    LauncherIcon(
+                            imageVector = MinimalIcons.iconFor("alarm"),
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onBackground,
+                            iconSize = 14.dp,
+                            outlined = outlined,
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    if (outlined) {
+                        OutlinedText(
+                                text = alarm,
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onBackground,
+                                outlineWidth = 1.5f,
+                        )
+                    } else {
+                        Text(
+                                text = alarm,
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onBackground,
+                        )
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeViewModel.kt
@@ -1,6 +1,7 @@
 package com.lu4p.fokuslauncher.ui.home
 
 import android.Manifest
+import android.app.AlarmManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -122,6 +123,8 @@ data class HomeClockUiState(
     val batteryPercent: Int = 0,
     /** Mirrors [DateFormat.is24HourFormat] for the home clock layout and semantics. */
     val is24HourFormat: Boolean = true,
+    /** Next upcoming alarm text (e.g. "Wed 07:15"), or null when no alarm is set. */
+    val nextAlarm: String? = null,
 )
 
 data class HomeWeatherUiState(
@@ -331,6 +334,13 @@ class HomeViewModel @Inject constructor(
         }
     }
 
+    private val alarmChangedReceiver = object : BroadcastReceiver() {
+        override fun onReceive(ctx: Context?, intent: Intent?) {
+            if (intent?.action != AlarmManager.ACTION_NEXT_ALARM_CLOCK_CHANGED) return
+            refreshNextAlarm()
+        }
+    }
+
     /**
      * JVM default timezone is fixed at process start and does not track system changes until we
      * handle [Intent.ACTION_TIMEZONE_CHANGED] and refresh cached formatters.
@@ -359,7 +369,9 @@ class HomeViewModel @Inject constructor(
         startClockTicker()
         registerBatteryReceiver()
         registerTimezoneChangedReceiver()
+        registerAlarmChangedReceiver()
         updateBattery()
+        refreshNextAlarm()
         observeHomeAlignment()
         observeLauncherFontScale()
         observePhotoWallpaperAppearance()
@@ -384,7 +396,7 @@ class HomeViewModel @Inject constructor(
     }
 
     override fun onCleared() {
-        listOf(batteryChangedReceiver, timezoneChangedReceiver).forEach { receiver ->
+        listOf(batteryChangedReceiver, timezoneChangedReceiver, alarmChangedReceiver).forEach { receiver ->
             try {
                 context.unregisterReceiver(receiver)
             } catch (_: IllegalArgumentException) {
@@ -788,6 +800,9 @@ class HomeViewModel @Inject constructor(
                 if (updated != current) {
                     _clockUiState.value = updated
                 }
+                if ((now.time / 1000) % 60 == 0L) {
+                    refreshNextAlarm()
+                }
                 refreshWorldClockTimes(now.time)
                 refreshCountdownRemaining(now.time)
                 delay(1_000)
@@ -818,6 +833,13 @@ class HomeViewModel @Inject constructor(
         )
     }
 
+    private fun registerAlarmChangedReceiver() {
+        registerPrivateNotExportedReceiver(
+            alarmChangedReceiver,
+            IntentFilter(AlarmManager.ACTION_NEXT_ALARM_CLOCK_CHANGED)
+        )
+    }
+
     private fun setBatteryPercentFromIntent(intent: Intent) {
         val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
         val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
@@ -826,6 +848,27 @@ class HomeViewModel @Inject constructor(
         if (current.batteryPercent != percent) {
             _clockUiState.value = current.copy(batteryPercent = percent)
         }
+    }
+
+    private fun refreshNextAlarm() {
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val nextAlarm = alarmManager.nextAlarmClock
+        val alarmText = if (nextAlarm != null) {
+            formatNextAlarm(nextAlarm.triggerTime)
+        } else {
+            null
+        }
+        val current = _clockUiState.value
+        if (current.nextAlarm != alarmText) {
+            _clockUiState.value = current.copy(nextAlarm = alarmText)
+        }
+    }
+
+    private fun formatNextAlarm(triggerTime: Long): String {
+        val is24Hour = DateFormat.is24HourFormat(context)
+        val skeleton = if (is24Hour) "E HHmm" else "E hmm"
+        val pattern = DateFormat.getBestDateTimePattern(Locale.getDefault(), skeleton)
+        return DateFormat.format(pattern, triggerTime).toString()
     }
 
     private fun updateBattery() {


### PR DESCRIPTION
## Reason behind this change

On many lock screens and many clock widgets, you'll see the next alarm shown underneath the time. This is useful, rather than having to tap on the clock.

I believe it's a positive UX improvement that reduces interactions and surfaces useful information to be available at a glance.

## Changes

- Add nextAlarm to HomeClockUiState to track the upcoming system alarm.
- Implement a broadcast receiver for ACTION_NEXT_ALARM_CLOCK_CHANGED in HomeViewModel to update the UI when alarms are set or modified.
- Add logic to fetch and format the next alarm time (e.g., "Wed 07:15") using AlarmManager.getNextAlarmClock().
- Update HomeScreen to display the alarm info with an icon directly under the time, matching common lock screen widget styles.
- Make the alarm display clickable to quickly open the system clock/alarm app.

## Screenshot

<img width="1280" height="2856" alt="image" src="https://github.com/user-attachments/assets/41eeb27b-287f-4482-b89e-e9db8c367ef4" />