### PR TITLE
Add charging indicator to battery percentage

### DIFF
--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/components/DateBatteryRow.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/components/DateBatteryRow.kt
@@ -4,12 +4,18 @@ import com.lu4p.fokuslauncher.ui.util.clickableNoRippleWithSystemSound
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Bolt
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.lu4p.fokuslauncher.ui.theme.LocalPhotoWallpaperOutlineWidthDp
@@ -23,6 +29,7 @@ fun DateBatteryRow(
     date: String,
     batteryPercent: Int,
     modifier: Modifier = Modifier,
+    isCharging: Boolean = false,
     showDate: Boolean = true,
     showBattery: Boolean = true,
     outlined: Boolean = false,
@@ -33,6 +40,8 @@ fun DateBatteryRow(
     val color = MaterialTheme.colorScheme.onBackground
     val backdropStrength = LocalPhotoWallpaperOutlineWidthDp.current
     val useSharedBackdrop = outlined && backdropStrength > 0f
+    val batteryPercentText = "$batteryPercent%"
+
     Row(verticalAlignment = Alignment.CenterVertically, modifier = modifier) {
         if (showDate) {
             Box(
@@ -64,26 +73,71 @@ fun DateBatteryRow(
                     }
                     if (showBattery) {
                         Spacer(modifier = Modifier.width(8.dp))
-                        if (outlined && !useSharedBackdrop) {
-                            OutlinedText(text = "$batteryPercent%", style = style, color = color)
-                        } else {
-                            Text(text = "$batteryPercent%", style = style, color = color)
-                        }
+                        BatteryDisplay(
+                            percentText = batteryPercentText,
+                            isCharging = isCharging,
+                            style = style,
+                            color = color,
+                            outlined = outlined,
+                            useSharedBackdrop = useSharedBackdrop
+                        )
                     }
                 }
             }
-        } else if (showBattery) {
-            if (useSharedBackdrop) {
-                Text(
-                        text = "$batteryPercent%",
-                        style = style,
-                        color = color,
-                        modifier = Modifier.photoBackdropPill(backdropStrength)
+        } else {
+            BatteryDisplay(
+                percentText = batteryPercentText,
+                isCharging = isCharging,
+                style = style,
+                color = color,
+                outlined = outlined,
+                useSharedBackdrop = useSharedBackdrop,
+                modifier = if (useSharedBackdrop) Modifier.photoBackdropPill(backdropStrength) else Modifier
+            )
+        }
+    }
+}
+
+@Composable
+private fun BatteryDisplay(
+    percentText: String,
+    isCharging: Boolean,
+    style: androidx.compose.ui.text.TextStyle,
+    color: Color,
+    outlined: Boolean,
+    useSharedBackdrop: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Row(verticalAlignment = Alignment.CenterVertically, modifier = modifier) {
+        if (outlined && !useSharedBackdrop) {
+            OutlinedText(text = percentText, style = style, color = color)
+            if (isCharging) {
+                Spacer(modifier = Modifier.width(2.dp))
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        imageVector = Icons.Outlined.Bolt,
+                        contentDescription = null,
+                        tint = Color.Black,
+                        modifier = Modifier.size(20.dp).offset(x = 1.dp, y = 1.dp)
+                    )
+                    Icon(
+                        imageVector = Icons.Outlined.Bolt,
+                        contentDescription = null,
+                        tint = color,
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+            }
+        } else {
+            Text(text = percentText, style = style, color = color)
+            if (isCharging) {
+                Spacer(modifier = Modifier.width(2.dp))
+                Icon(
+                    imageVector = Icons.Outlined.Bolt,
+                    contentDescription = null,
+                    tint = color,
+                    modifier = Modifier.size(20.dp)
                 )
-            } else if (outlined) {
-                OutlinedText(text = "$batteryPercent%", style = style, color = color)
-            } else {
-                Text(text = "$batteryPercent%", style = style, color = color)
             }
         }
     }

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeScreen.kt
@@ -510,6 +510,7 @@ private fun HomeWidgetsSection(
         DateBatteryRow(
                 date = clockUiState.currentDate,
                 batteryPercent = clockUiState.batteryPercent,
+                isCharging = clockUiState.isCharging,
                 showDate = uiState.showHomeDate,
                 showBattery = uiState.showHomeBattery,
                 outlined = outlined,

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeViewModel.kt
@@ -120,6 +120,7 @@ data class HomeClockUiState(
     val currentTime: String = "",
     val currentDate: String = "",
     val batteryPercent: Int = 0,
+    val isCharging: Boolean = false,
     /** Mirrors [DateFormat.is24HourFormat] for the home clock layout and semantics. */
     val is24HourFormat: Boolean = true,
 )
@@ -821,10 +822,14 @@ class HomeViewModel @Inject constructor(
     private fun setBatteryPercentFromIntent(intent: Intent) {
         val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
         val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
+        val status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1)
+        val isCharging =
+                status == BatteryManager.BATTERY_STATUS_CHARGING ||
+                        status == BatteryManager.BATTERY_STATUS_FULL
         val percent = if (level >= 0 && scale > 0) (level * 100) / scale else 0
         val current = _clockUiState.value
-        if (current.batteryPercent != percent) {
-            _clockUiState.value = current.copy(batteryPercent = percent)
+        if (current.batteryPercent != percent || current.isCharging != isCharging) {
+            _clockUiState.value = current.copy(batteryPercent = percent, isCharging = isCharging)
         }
     }
 
@@ -837,10 +842,12 @@ class HomeViewModel @Inject constructor(
             if (batteryIntent != null) {
                 setBatteryPercentFromIntent(batteryIntent)
             } else {
-                _clockUiState.value = _clockUiState.value.copy(batteryPercent = 0)
+                _clockUiState.value =
+                        _clockUiState.value.copy(batteryPercent = 0, isCharging = false)
             }
         } catch (_: Exception) {
-            _clockUiState.value = _clockUiState.value.copy(batteryPercent = 0)
+            _clockUiState.value =
+                    _clockUiState.value.copy(batteryPercent = 0, isCharging = false)
         }
     }
 

--- a/app/src/test/java/com/lu4p/fokuslauncher/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/lu4p/fokuslauncher/ui/home/HomeViewModelTest.kt
@@ -223,10 +223,15 @@ class HomeViewModelTest {
         }
     }
 
-    private fun mockBatteryStickyIntent(level: Int = 75, scale: Int = 100): Intent {
+    private fun mockBatteryStickyIntent(
+            level: Int = 75,
+            scale: Int = 100,
+            status: Int = BatteryManager.BATTERY_STATUS_DISCHARGING
+    ): Intent {
         val batteryIntent = mockk<Intent>(relaxed = true)
         every { batteryIntent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) } returns level
         every { batteryIntent.getIntExtra(BatteryManager.EXTRA_SCALE, -1) } returns scale
+        every { batteryIntent.getIntExtra(BatteryManager.EXTRA_STATUS, -1) } returns status
         return batteryIntent
     }
 
@@ -447,19 +452,24 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun `refreshBattery updates battery percentage`() {
+    fun `refreshBattery updates battery percentage and charging status`() {
         val batteryIntent = mockk<Intent>(relaxed = true)
         every { batteryIntent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) } returns 50
         every { batteryIntent.getIntExtra(BatteryManager.EXTRA_SCALE, -1) } returns 100
+        every { batteryIntent.getIntExtra(BatteryManager.EXTRA_STATUS, -1) } returns
+                BatteryManager.BATTERY_STATUS_DISCHARGING
         stubNullReceiverBatterySticky(batteryIntent)
 
         val viewModel = createViewModel()
         testDispatcher.scheduler.advanceTimeBy(100)
 
         every { batteryIntent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) } returns 30
+        every { batteryIntent.getIntExtra(BatteryManager.EXTRA_STATUS, -1) } returns
+                BatteryManager.BATTERY_STATUS_CHARGING
         viewModel.refreshBattery()
 
         assertEquals(30, viewModel.clockUiState.value.batteryPercent)
+        assertTrue(viewModel.clockUiState.value.isCharging)
     }
 
     @Test


### PR DESCRIPTION
## Reason behind this change

By default, the status bar is disabled, which is aesthetically cleaner. However, when charging your device, other than the current battery percentage, there's no visual indicator as to whether the device is charging or not.

I've added a little glyph next to the battery percentage when the device is charging, surfacing useful at a glance information to the user.

## Changes

- Update HomeViewModel to track battery charging status from system broadcasts.
- Modify DateBatteryRow to display a Material Bolt icon to the right of the percentage when charging.
- Ensure the icon follows text color and supports outlined styling for visibility on photo wallpapers.
- Update HomeViewModelTest to verify charging state logic.

## Screenshot

<img width="1280" height="2856" alt="image" src="https://github.com/user-attachments/assets/32f8bc25-dc16-431a-8b78-7c68c8a6ef83" />
