### PR TITLE
Expand home favourite tap zones and enable ripple feedback

### DIFF
--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeScreen.kt
@@ -2,6 +2,7 @@ package com.lu4p.fokuslauncher.ui.home
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -694,6 +695,7 @@ private fun HomeFavoritesSection(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     onLabelClick = onLabelClick,
                     onLabelLongPress = onLabelLongPress,
+                    modifier = Modifier.fillMaxWidth(),
                     outlined = outlined,
                     notificationIndicatorUiState = notificationIndicatorUiState,
                 )
@@ -866,8 +868,9 @@ private fun FavoriteAppItem(
     Column(
             horizontalAlignment = horizontalAlignment,
             modifier =
-                    Modifier.combinedClickableWithSystemSound(
-                                    indication = null,
+                    Modifier.fillMaxWidth()
+                            .combinedClickableWithSystemSound(
+                                    indication = LocalIndication.current,
                                     interactionSource = remember { MutableInteractionSource() },
                                     onClick = onClick,
                                     onLongClick = onLongPress,


### PR DESCRIPTION
## Reason for this change

At present, if you swipe up to search (or then scroll to find an app) and tap on an app listing, its tap zone is full-width, making it easy for right-handed users tapping with their thumb.
However, on the home screen, where most time will be spent, it's limited to the length of the content, often making it hard to reach, especially for short app names.

This makes it full width, save for the gutter that accommodates the app shortcuts to the right.

## Changes

- Modify FavoriteAppItem and FavoritesList to use fillMaxWidth, allowing tap zones to occupy all available horizontal space up to the shortcuts gutter.
- Enable standard ripple feedback for home favourites by replacing indication = null with LocalIndication.current.
- Improve consistency with the app drawer and search experience.