### PR TITLE
Implement app shortcuts in home screen long-press menu

### DIFF
--- a/app/src/main/java/com/lu4p/fokuslauncher/data/model/AppShortcutAction.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/model/AppShortcutAction.kt
@@ -7,12 +7,12 @@ import android.graphics.drawable.Drawable
  * Includes the app launch action and launcher-published long-press actions.
  */
 data class AppShortcutAction(
-        val appLabel: String,
-        val actionLabel: String,
-        val target: ShortcutTarget,
-        /** Same encoding as [FavoriteApp.profileKey] (`"0"` = owner). */
-        val profileKey: String = "0",
-        val icon: Drawable? = null,
+    val appLabel: String,
+    val actionLabel: String,
+    val target: ShortcutTarget,
+    /** Same encoding as [FavoriteApp.profileKey] (`"0"` = owner). */
+    val profileKey: String = "0",
+    val icon: Drawable? = null,
 ) {
     /** Stable list / selection id (profile + target). */
     val id: String get() = "$profileKey|${ShortcutTarget.encode(target)}"

--- a/app/src/main/java/com/lu4p/fokuslauncher/data/model/AppShortcutAction.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/model/AppShortcutAction.kt
@@ -1,15 +1,18 @@
 package com.lu4p.fokuslauncher.data.model
 
+import android.graphics.drawable.Drawable
+
 /**
  * A selectable shortcut action for right-side home shortcuts.
  * Includes the app launch action and launcher-published long-press actions.
  */
 data class AppShortcutAction(
-    val appLabel: String,
-    val actionLabel: String,
-    val target: ShortcutTarget,
-    /** Same encoding as [FavoriteApp.profileKey] (`"0"` = owner). */
-    val profileKey: String = "0",
+        val appLabel: String,
+        val actionLabel: String,
+        val target: ShortcutTarget,
+        /** Same encoding as [FavoriteApp.profileKey] (`"0"` = owner). */
+        val profileKey: String = "0",
+        val icon: Drawable? = null,
 ) {
     /** Stable list / selection id (profile + target). */
     val id: String get() = "$profileKey|${ShortcutTarget.encode(target)}"

--- a/app/src/main/java/com/lu4p/fokuslauncher/data/model/DrawerAppSortMode.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/model/DrawerAppSortMode.kt
@@ -19,7 +19,15 @@ enum class DrawerAppSortMode(@param:StringRes val labelRes: Int) {
 
 /** Stable profile segment for [userHandle]: owner user is `"0"`. */
 fun appProfileKey(userHandle: UserHandle?): String {
-    if (userHandle == null || userHandle == Process.myUserHandle()) return "0"
+    if (userHandle == null) return "0"
+    // Process.myUserHandle() throws on the plain JVM unit-test classpath (not Robolectric).
+    val myUser =
+            try {
+                Process.myUserHandle()
+            } catch (_: RuntimeException) {
+                null
+            }
+    if (myUser != null && userHandle == myUser) return "0"
     return userHandle.hashCode().toString()
 }
 

--- a/app/src/main/java/com/lu4p/fokuslauncher/data/model/DrawerAppSortMode.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/model/DrawerAppSortMode.kt
@@ -1,5 +1,6 @@
 package com.lu4p.fokuslauncher.data.model
 
+import android.os.Process
 import android.os.UserHandle
 import androidx.annotation.StringRes
 import com.lu4p.fokuslauncher.R
@@ -17,8 +18,10 @@ enum class DrawerAppSortMode(@param:StringRes val labelRes: Int) {
 }
 
 /** Stable profile segment for [userHandle]: owner user is `"0"`. */
-fun appProfileKey(userHandle: UserHandle?): String =
-    userHandle?.hashCode()?.toString() ?: "0"
+fun appProfileKey(userHandle: UserHandle?): String {
+    if (userHandle == null || userHandle == Process.myUserHandle()) return "0"
+    return userHandle.hashCode().toString()
+}
 
 /** Stable key for open counts, list rows, and matching [FavoriteApp.profileKey]. */
 fun drawerOpenCountKey(packageName: String, profileKey: String): String =

--- a/app/src/main/java/com/lu4p/fokuslauncher/data/repository/AppRepository.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/repository/AppRepository.kt
@@ -1044,6 +1044,7 @@ constructor(
             .asSequence()
             .filter { it.isEnabled }
             .distinctBy { it.id }
+            .sortedBy { it.rank }
             .map { info ->
                 val shortcutLabel =
                     info.shortLabel?.toString()?.trim().takeUnless { it.isNullOrEmpty() }

--- a/app/src/main/java/com/lu4p/fokuslauncher/data/repository/AppRepository.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/repository/AppRepository.kt
@@ -979,23 +979,23 @@ constructor(
         val actions = mutableListOf<AppShortcutAction>()
 
         actions.add(
-                AppShortcutAction(
-                        appLabel = context.getString(R.string.shortcut_target_phone),
-                        actionLabel = context.getString(R.string.shortcut_open_dialer),
-                        target = ShortcutTarget.PhoneDial,
-                        profileKey = "0",
-                )
+            AppShortcutAction(
+                appLabel = context.getString(R.string.shortcut_target_phone),
+                actionLabel = context.getString(R.string.shortcut_open_dialer),
+                target = ShortcutTarget.PhoneDial,
+                profileKey = "0",
+            )
         )
         apps.filter { it.launcherShortcutId == null }.forEach { app ->
             val profileKey = appProfileKey(app.userHandle)
             actions.add(
-                    AppShortcutAction(
-                            appLabel = app.label,
-                            actionLabel = AppShortcutAction.OPEN_APP_LABEL,
-                            target = ShortcutTarget.App(app.packageName),
-                            profileKey = profileKey,
-                            icon = app.icon,
-                    )
+                AppShortcutAction(
+                    appLabel = app.label,
+                    actionLabel = AppShortcutAction.OPEN_APP_LABEL,
+                    target = ShortcutTarget.App(app.packageName),
+                    profileKey = profileKey,
+                    icon = app.icon,
+                )
             )
 
             if (app.userHandle != null) {
@@ -1004,9 +1004,9 @@ constructor(
         }
 
         return actions.distinctBy { it.id }.sortedWith(
-                compareBy<AppShortcutAction> { it.profileKey }
-                        .thenBy { it.appLabel.lowercase() }
-                        .thenBy { it.actionLabel.lowercase() }
+            compareBy<AppShortcutAction> { it.profileKey }
+                .thenBy { it.appLabel.lowercase() }
+                .thenBy { it.actionLabel.lowercase() }
         )
     }
 
@@ -1019,58 +1019,58 @@ constructor(
 
         // Find the app label
         val appLabel =
-                getInstalledApps().find { it.packageName == packageName && it.userHandle == user }?.label
-                        ?: packageName
+            getInstalledApps().find { it.packageName == packageName && it.userHandle == user }?.label
+                ?: packageName
 
         val shortcuts =
-                try {
-                    val queryFlags =
-                            LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC or
-                                    LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST or
-                                    LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED or
-                                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                                        LauncherApps.ShortcutQuery.FLAG_MATCH_CACHED
-                                    } else {
-                                        0
-                                    }
-                    val query =
-                            LauncherApps.ShortcutQuery().setPackage(packageName).setQueryFlags(queryFlags)
-                    launcherApps.getShortcuts(query, user).orEmpty()
-                } catch (_: Exception) {
-                    emptyList()
-                }
+            try {
+                val queryFlags =
+                    LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC or
+                        LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST or
+                        LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED or
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                            LauncherApps.ShortcutQuery.FLAG_MATCH_CACHED
+                        } else {
+                            0
+                        }
+                val query =
+                    LauncherApps.ShortcutQuery().setPackage(packageName).setQueryFlags(queryFlags)
+                launcherApps.getShortcuts(query, user).orEmpty()
+            } catch (_: Exception) {
+                emptyList()
+            }
 
         return shortcuts
-                .asSequence()
-                .filter { it.isEnabled }
-                .distinctBy { it.id }
-                .map { info ->
-                    val shortcutLabel =
-                            info.shortLabel?.toString()?.trim().takeUnless { it.isNullOrEmpty() }
-                                    ?: info.longLabel?.toString()?.trim().takeUnless { it.isNullOrEmpty() }
-                                    ?: context.getString(R.string.shortcut_generic_label)
-                    val shortcutIcon =
-                            try {
-                                launcherApps.getShortcutIconDrawable(
-                                        info,
-                                        context.resources.displayMetrics.densityDpi
-                                )
-                            } catch (_: Exception) {
-                                null
-                            }
-                    AppShortcutAction(
-                            appLabel = appLabel,
-                            actionLabel = shortcutLabel,
-                            target =
-                                    ShortcutTarget.LauncherShortcut(
-                                            packageName = packageName,
-                                            shortcutId = info.id,
-                                    ),
-                            profileKey = profileKey,
-                            icon = shortcutIcon,
-                    )
-                }
-                .toList()
+            .asSequence()
+            .filter { it.isEnabled }
+            .distinctBy { it.id }
+            .map { info ->
+                val shortcutLabel =
+                    info.shortLabel?.toString()?.trim().takeUnless { it.isNullOrEmpty() }
+                        ?: info.longLabel?.toString()?.trim().takeUnless { it.isNullOrEmpty() }
+                        ?: context.getString(R.string.shortcut_generic_label)
+                val shortcutIcon =
+                    try {
+                        launcherApps.getShortcutIconDrawable(
+                            info,
+                            context.resources.displayMetrics.densityDpi
+                        )
+                    } catch (_: Exception) {
+                        null
+                    }
+                AppShortcutAction(
+                    appLabel = appLabel,
+                    actionLabel = shortcutLabel,
+                    target =
+                        ShortcutTarget.LauncherShortcut(
+                            packageName = packageName,
+                            shortcutId = info.id,
+                        ),
+                    profileKey = profileKey,
+                    icon = shortcutIcon,
+                )
+            }
+            .toList()
     }
 
     /**
@@ -1081,27 +1081,27 @@ constructor(
         val launcherApps = launcherAppsOrNull() ?: return null
 
         val user =
-                userManagerOrNull()
-                        ?.userProfiles
-                        ?.find { appProfileKey(it) == action.profileKey }
-                        ?: Process.myUserHandle()
+            userManagerOrNull()
+                ?.userProfiles
+                ?.find { appProfileKey(it) == action.profileKey }
+                ?: Process.myUserHandle()
 
         val query =
-                LauncherApps.ShortcutQuery()
-                        .setPackage(target.packageName)
-                        .setShortcutIds(listOf(target.shortcutId))
-                        .setQueryFlags(
-                                LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC or
-                                        LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST or
-                                        LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED,
-                        )
+            LauncherApps.ShortcutQuery()
+                .setPackage(target.packageName)
+                .setShortcutIds(listOf(target.shortcutId))
+                .setQueryFlags(
+                    LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC or
+                        LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST or
+                        LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED,
+                )
 
         val shortcuts =
-                try {
-                    launcherApps.getShortcuts(query, user).orEmpty()
-                } catch (_: Exception) {
-                    emptyList()
-                }
+            try {
+                launcherApps.getShortcuts(query, user).orEmpty()
+            } catch (_: Exception) {
+                emptyList()
+            }
 
         val info = shortcuts.firstOrNull() ?: return null
         return try {

--- a/app/src/main/java/com/lu4p/fokuslauncher/data/repository/AppRepository.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/repository/AppRepository.kt
@@ -644,7 +644,12 @@ constructor(
         mainHandler.postDelayed(delayedInstalledAppsRefresh, INSTALLED_APPS_REFRESH_RETRY_DELAY_MS)
     }
 
-    private fun profileKeyForUser(user: UserHandle): String =
+    fun getUserHandleForProfile(profileKey: String): UserHandle? {
+        if (profileKey == "0") return Process.myUserHandle()
+        return userManagerOrNull()?.userProfiles?.find { appProfileKey(it) == profileKey }
+    }
+
+    fun profileKeyForUser(user: UserHandle): String =
             if (user == Process.myUserHandle()) "0" else appProfileKey(user)
 
     fun getInstalledAppsVersion(): StateFlow<Long> = installedAppsVersion
@@ -973,9 +978,6 @@ constructor(
         val apps = getInstalledApps()
         val actions = mutableListOf<AppShortcutAction>()
 
-        val launcherApps = launcherAppsOrNull()
-
-        val myUser = Process.myUserHandle()
         actions.add(
                 AppShortcutAction(
                         appLabel = context.getString(R.string.shortcut_target_phone),
@@ -987,65 +989,128 @@ constructor(
         apps.filter { it.launcherShortcutId == null }.forEach { app ->
             val profileKey = appProfileKey(app.userHandle)
             actions.add(
-                AppShortcutAction(
-                    appLabel = app.label,
-                    actionLabel = AppShortcutAction.OPEN_APP_LABEL,
-                    target = ShortcutTarget.App(app.packageName),
-                    profileKey = profileKey,
-                )
+                    AppShortcutAction(
+                            appLabel = app.label,
+                            actionLabel = AppShortcutAction.OPEN_APP_LABEL,
+                            target = ShortcutTarget.App(app.packageName),
+                            profileKey = profileKey,
+                            icon = app.icon,
+                    )
             )
 
-            if (launcherApps == null) return@forEach
-
-            val shortcutUser = app.userHandle ?: myUser
-            val shortcuts = try {
-                val queryFlags =
-                        LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC or
-                                LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST or
-                                LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED or
-                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                                    LauncherApps.ShortcutQuery.FLAG_MATCH_CACHED
-                                } else {
-                                    0
-                                }
-                val query =
-                        LauncherApps.ShortcutQuery()
-                                .setPackage(app.packageName)
-                                .setQueryFlags(queryFlags)
-                launcherApps.getShortcuts(query, shortcutUser).orEmpty()
-            } catch (_: Exception) {
-                emptyList()
+            if (app.userHandle != null) {
+                actions.addAll(getShortcutsForApp(app.packageName, app.userHandle))
             }
-
-            shortcuts
-                .asSequence()
-                .filter { it.isEnabled }
-                .distinctBy { it.id }
-                .forEach { info ->
-                    val shortcutLabel =
-                        info.shortLabel?.toString()?.trim().takeUnless { it.isNullOrEmpty() }
-                            ?: info.longLabel?.toString()?.trim().takeUnless { it.isNullOrEmpty() }
-                            ?: context.getString(R.string.shortcut_generic_label)
-                    actions.add(
-                        AppShortcutAction(
-                            appLabel = app.label,
-                            actionLabel = shortcutLabel,
-                            target = ShortcutTarget.LauncherShortcut(
-                                packageName = app.packageName,
-                                shortcutId = info.id
-                            ),
-                            profileKey = profileKey,
-                        )
-                    )
-                }
         }
 
         return actions.distinctBy { it.id }.sortedWith(
-            compareBy<AppShortcutAction> { it.profileKey }
-                .thenBy { it.appLabel.lowercase() }
-                .thenBy { it.actionLabel.lowercase() }
+                compareBy<AppShortcutAction> { it.profileKey }
+                        .thenBy { it.appLabel.lowercase() }
+                        .thenBy { it.actionLabel.lowercase() }
         )
     }
+
+    /**
+     * Returns all launcher shortcut actions published by a specific app.
+     */
+    fun getShortcutsForApp(packageName: String, user: UserHandle): List<AppShortcutAction> {
+        val launcherApps = launcherAppsOrNull() ?: return emptyList()
+        val profileKey = profileKeyForUser(user)
+
+        // Find the app label
+        val appLabel =
+                getInstalledApps().find { it.packageName == packageName && it.userHandle == user }?.label
+                        ?: packageName
+
+        val shortcuts =
+                try {
+                    val queryFlags =
+                            LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC or
+                                    LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST or
+                                    LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED or
+                                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                                        LauncherApps.ShortcutQuery.FLAG_MATCH_CACHED
+                                    } else {
+                                        0
+                                    }
+                    val query =
+                            LauncherApps.ShortcutQuery().setPackage(packageName).setQueryFlags(queryFlags)
+                    launcherApps.getShortcuts(query, user).orEmpty()
+                } catch (_: Exception) {
+                    emptyList()
+                }
+
+        return shortcuts
+                .asSequence()
+                .filter { it.isEnabled }
+                .distinctBy { it.id }
+                .map { info ->
+                    val shortcutLabel =
+                            info.shortLabel?.toString()?.trim().takeUnless { it.isNullOrEmpty() }
+                                    ?: info.longLabel?.toString()?.trim().takeUnless { it.isNullOrEmpty() }
+                                    ?: context.getString(R.string.shortcut_generic_label)
+                    val shortcutIcon =
+                            try {
+                                launcherApps.getShortcutIconDrawable(
+                                        info,
+                                        context.resources.displayMetrics.densityDpi
+                                )
+                            } catch (_: Exception) {
+                                null
+                            }
+                    AppShortcutAction(
+                            appLabel = appLabel,
+                            actionLabel = shortcutLabel,
+                            target =
+                                    ShortcutTarget.LauncherShortcut(
+                                            packageName = packageName,
+                                            shortcutId = info.id,
+                                    ),
+                            profileKey = profileKey,
+                            icon = shortcutIcon,
+                    )
+                }
+                .toList()
+    }
+
+    /**
+     * Fetches the icon for a specific launcher shortcut.
+     */
+    fun getShortcutIcon(action: AppShortcutAction): Drawable? {
+        val target = action.target as? ShortcutTarget.LauncherShortcut ?: return null
+        val launcherApps = launcherAppsOrNull() ?: return null
+
+        val user =
+                userManagerOrNull()
+                        ?.userProfiles
+                        ?.find { appProfileKey(it) == action.profileKey }
+                        ?: Process.myUserHandle()
+
+        val query =
+                LauncherApps.ShortcutQuery()
+                        .setPackage(target.packageName)
+                        .setShortcutIds(listOf(target.shortcutId))
+                        .setQueryFlags(
+                                LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC or
+                                        LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST or
+                                        LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED,
+                        )
+
+        val shortcuts =
+                try {
+                    launcherApps.getShortcuts(query, user).orEmpty()
+                } catch (_: Exception) {
+                    emptyList()
+                }
+
+        val info = shortcuts.firstOrNull() ?: return null
+        return try {
+            launcherApps.getShortcutIconDrawable(info, context.resources.displayMetrics.densityDpi)
+        } catch (_: Exception) {
+            null
+        }
+    }
+
 
     suspend fun getAllShortcutActionsOnBackground(): List<AppShortcutAction> =
             withContext(Dispatchers.IO) { getAllShortcutActions() }

--- a/app/src/main/java/com/lu4p/fokuslauncher/data/repository/AppRepository.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/repository/AppRepository.kt
@@ -649,8 +649,7 @@ constructor(
         return userManagerOrNull()?.userProfiles?.find { appProfileKey(it) == profileKey }
     }
 
-    fun profileKeyForUser(user: UserHandle): String =
-            if (user == Process.myUserHandle()) "0" else appProfileKey(user)
+    fun profileKeyForUser(user: UserHandle): String = appProfileKey(user)
 
     fun getInstalledAppsVersion(): StateFlow<Long> = installedAppsVersion
     fun getRemovedPackages(): SharedFlow<RemovedApp> = removedPackages.asSharedFlow()

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/components/FokusBottomSheet.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/components/FokusBottomSheet.kt
@@ -1,9 +1,13 @@
 package com.lu4p.fokuslauncher.ui.components
 
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -13,6 +17,9 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 
 private val BottomSheetScrimAlpha = 0.56f
@@ -25,6 +32,12 @@ fun FokusBottomSheet(
         onDismissRequest: () -> Unit,
         modifier: Modifier = Modifier,
         sheetState: SheetState = rememberModalBottomSheetState(),
+        /**
+         * When set, the sheet opens at this fraction of the screen height. If content is taller,
+         * the sheet can be swiped up to full height; otherwise height stays fixed at the peek.
+         * When null, height follows content.
+         */
+        contentHeightFraction: Float? = null,
         content: @Composable ColumnScope.() -> Unit,
 ) {
     ModalBottomSheet(
@@ -42,9 +55,85 @@ fun FokusBottomSheet(
             },
             modifier = modifier,
     ) {
-        Column(
-                modifier = Modifier.fillMaxWidth().padding(bottom = 32.dp),
-                content = content,
-        )
+        if (contentHeightFraction != null) {
+            PeekExpandableSheetContent(
+                    peekHeightFraction = contentHeightFraction,
+                    content = content,
+            )
+        } else {
+            Column(
+                    modifier =
+                            Modifier.fillMaxWidth()
+                                    .verticalScroll(rememberScrollState())
+                                    .padding(bottom = 32.dp),
+                    content = content,
+            )
+        }
+    }
+}
+
+/**
+ * Peek-height sheet body: fixed open height, swipe-to-expand only when content overflows the peek.
+ *
+ * Overflowing content requests the full available height so [ModalBottomSheet] exposes its
+ * partially-expanded (open) and fully-expanded anchors.
+ */
+@Composable
+private fun PeekExpandableSheetContent(
+        peekHeightFraction: Float,
+        content: @Composable ColumnScope.() -> Unit,
+) {
+    val screenHeight = LocalConfiguration.current.screenHeightDp.dp
+    val peekHeight = screenHeight * peekHeightFraction
+    val scrollState = rememberScrollState()
+
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val fullHeight = if (constraints.hasBoundedHeight) maxHeight else screenHeight
+
+        SubcomposeLayout(modifier = Modifier.fillMaxWidth()) { constraints ->
+            val maxBodyPx =
+                    if (constraints.hasBoundedHeight) constraints.maxHeight
+                    else fullHeight.roundToPx()
+            val peekPx = peekHeight.roundToPx().coerceAtMost(maxBodyPx)
+            val fullPx = fullHeight.roundToPx().coerceAtMost(maxBodyPx)
+
+            val contentHeight =
+                    subcompose("measure") {
+                                Column(modifier = Modifier.fillMaxWidth(), content = content)
+                            }
+                            .sumOf {
+                                it.measure(
+                                                constraints.copy(
+                                                        minHeight = 0,
+                                                        maxHeight = Constraints.Infinity,
+                                                ),
+                                        )
+                                        .height
+                            }
+
+            val overflowsPeek = contentHeight > peekPx
+            val bodyHeight = if (overflowsPeek) fullPx else peekPx
+
+            val placeable =
+                    subcompose("body") {
+                                Column(
+                                        modifier =
+                                                Modifier.fillMaxWidth()
+                                                        .height(bodyHeight.toDp())
+                                                        .verticalScroll(scrollState)
+                                                        .padding(bottom = 32.dp),
+                                        content = content,
+                                )
+                            }
+                            .first()
+                            .measure(
+                                    constraints.copy(
+                                            minHeight = bodyHeight,
+                                            maxHeight = bodyHeight,
+                                    ),
+                            )
+
+            layout(placeable.width, bodyHeight) { placeable.place(0, 0) }
+        }
     }
 }

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/components/LauncherIcon.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/components/LauncherIcon.kt
@@ -47,254 +47,254 @@ import com.lu4p.fokuslauncher.ui.theme.launcherIconDp
  */
 @Composable
 fun LauncherIcon(
-        imageVector: ImageVector,
-        contentDescription: String?,
-        modifier: Modifier = Modifier,
-        tint: Color? = null,
-        iconSize: Dp = 24.dp,
-        suppressGlow: Boolean = false,
-        outlined: Boolean = false,
+    imageVector: ImageVector,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    tint: Color? = null,
+    iconSize: Dp = 24.dp,
+    suppressGlow: Boolean = false,
+    outlined: Boolean = false,
 ) {
     LauncherIcon(
-            painter = rememberVectorPainter(imageVector),
-            contentDescription = contentDescription,
-            modifier = modifier,
-            tint = tint,
-            iconSize = iconSize,
-            suppressGlow = suppressGlow,
-            outlined = outlined,
+        painter = rememberVectorPainter(imageVector),
+        contentDescription = contentDescription,
+        modifier = modifier,
+        tint = tint,
+        iconSize = iconSize,
+        suppressGlow = suppressGlow,
+        outlined = outlined,
     )
 }
 
 @Composable
 fun LauncherIcon(
-        drawable: Drawable?,
-        contentDescription: String?,
-        modifier: Modifier = Modifier,
-        tint: Color? = null,
-        iconSize: Dp = 24.dp,
-        suppressGlow: Boolean = false,
-        outlined: Boolean = false,
+    drawable: Drawable?,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    tint: Color? = null,
+    iconSize: Dp = 24.dp,
+    suppressGlow: Boolean = false,
+    outlined: Boolean = false,
 ) {
     if (drawable == null) return
     val density = LocalDensity.current
 
     val (painter, canTint) =
-            remember(drawable, density, iconSize) {
-                val sizePx = with(density) { iconSize.toPx() }.toInt()
+        remember(drawable, density, iconSize) {
+            val sizePx = with(density) { iconSize.toPx() }.toInt()
 
-                var finalDrawable: Drawable = drawable
-                var isAdaptive = false
-                var monochrome = false
+            var finalDrawable: Drawable = drawable
+            var isAdaptive = false
+            var monochrome = false
 
-                if (drawable is android.graphics.drawable.AdaptiveIconDrawable) {
-                    isAdaptive = true
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                        drawable.monochrome?.let {
-                            finalDrawable = it
-                            monochrome = true
-                        }
+            if (drawable is android.graphics.drawable.AdaptiveIconDrawable) {
+                isAdaptive = true
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    drawable.monochrome?.let {
+                        finalDrawable = it
+                        monochrome = true
                     }
-                    if (!monochrome) {
-                        finalDrawable = drawable.foreground
-                    }
-                } else if (drawable is android.graphics.drawable.VectorDrawable ||
-                                drawable.javaClass.name.contains("VectorDrawable")
-                ) {
-                    monochrome = true
                 }
-
-                val bitmap =
-                        if (isAdaptive) {
-                            // Zoom in to fill the safe zone. Adaptive icons are 108dp with a 72dp
-                            // safe zone. To fill the space better, we scale up.
-                            val scale = 1.42f
-                            val drawSize = (sizePx * scale).toInt()
-                            val bmp =
-                                    android.graphics.Bitmap.createBitmap(
-                                            sizePx,
-                                            sizePx,
-                                            android.graphics.Bitmap.Config.ARGB_8888
-                                    )
-                            val canvas = android.graphics.Canvas(bmp)
-                            val offset = (sizePx - drawSize) / 2
-                            finalDrawable.setBounds(
-                                    offset,
-                                    offset,
-                                    sizePx - offset,
-                                    sizePx - offset
-                            )
-                            finalDrawable.draw(canvas)
-                            bmp
-                        } else {
-                            finalDrawable.toBitmap(width = sizePx, height = sizePx)
-                        }
-                BitmapPainter(bitmap.asImageBitmap()) to monochrome
+                if (!monochrome) {
+                    finalDrawable = drawable.foreground
+                }
+            } else if (drawable is android.graphics.drawable.VectorDrawable ||
+                drawable.javaClass.name.contains("VectorDrawable")
+            ) {
+                monochrome = true
             }
 
+            val bitmap =
+                if (isAdaptive) {
+                    // Zoom in to fill the safe zone. Adaptive icons are 108dp with a 72dp
+                    // safe zone. To fill the space better, we scale up.
+                    val scale = 1.42f
+                    val drawSize = (sizePx * scale).toInt()
+                    val bmp =
+                        android.graphics.Bitmap.createBitmap(
+                            sizePx,
+                            sizePx,
+                            android.graphics.Bitmap.Config.ARGB_8888
+                        )
+                    val canvas = android.graphics.Canvas(bmp)
+                    val offset = (sizePx - drawSize) / 2
+                    finalDrawable.setBounds(
+                        offset,
+                        offset,
+                        sizePx - offset,
+                        sizePx - offset
+                    )
+                    finalDrawable.draw(canvas)
+                    bmp
+                } else {
+                    finalDrawable.toBitmap(width = sizePx, height = sizePx)
+                }
+            BitmapPainter(bitmap.asImageBitmap()) to monochrome
+        }
+
     LauncherIcon(
-            painter = painter,
-            contentDescription = contentDescription,
-            modifier = modifier,
-            tint = if (canTint) tint else Color.Unspecified,
-            iconSize = iconSize,
-            suppressGlow = suppressGlow,
-            outlined = outlined,
+        painter = painter,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        tint = if (canTint) tint else Color.Unspecified,
+        iconSize = iconSize,
+        suppressGlow = suppressGlow,
+        outlined = outlined,
     )
 }
 
 @Composable
 fun LauncherIcon(
-        painter: Painter,
-        contentDescription: String?,
-        modifier: Modifier = Modifier,
-        tint: Color? = null,
-        iconSize: Dp = 24.dp,
-        suppressGlow: Boolean = false,
-        outlined: Boolean = false,
+    painter: Painter,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    tint: Color? = null,
+    iconSize: Dp = 24.dp,
+    suppressGlow: Boolean = false,
+    outlined: Boolean = false,
 ) {
     val glowSpec = LocalLauncherIconGlow.current
     val glow = if (suppressGlow) LauncherIconGlowSpec.None else glowSpec
     val resolvedTint =
-            if (tint == Color.Unspecified) {
-                Color.Unspecified
-            } else {
-                tint
-                        ?: if (glow.enabled) {
-                            MaterialTheme.colorScheme.onSurface
-                        } else {
-                            LocalContentColor.current
-                        }
-            }
+        if (tint == Color.Unspecified) {
+            Color.Unspecified
+        } else {
+            tint
+                ?: if (glow.enabled) {
+                    MaterialTheme.colorScheme.onSurface
+                } else {
+                    LocalContentColor.current
+                }
+        }
     val haloTint =
-            if (!glow.enabled) {
-                Color.Transparent
-            } else if (tint != null) {
-                resolvedTint
-            } else {
-                glow.haloColor
-            }
+        if (!glow.enabled) {
+            Color.Transparent
+        } else if (tint != null) {
+            resolvedTint
+        } else {
+            glow.haloColor
+        }
     val scaledSize = iconSize.launcherIconDp()
     if (!glow.enabled && !outlined) {
         Icon(
-                painter = painter,
-                contentDescription = contentDescription,
-                modifier = modifier.size(scaledSize),
-                tint = resolvedTint,
+            painter = painter,
+            contentDescription = contentDescription,
+            modifier = modifier.size(scaledSize),
+            tint = resolvedTint,
         )
         return
     }
     val density = LocalDensity.current
     val fontBoost =
-            LocalLauncherFontScale.current.coerceIn(LauncherFontScale.MIN, LauncherFontScale.MAX)
+        LocalLauncherFontScale.current.coerceIn(LauncherFontScale.MIN, LauncherFontScale.MAX)
     // Stronger than earlier subtle bloom so icons visually match the bold text shadow.
     val blurRadiusPx = with(density) { (10f * fontBoost).dp.toPx() }
     val outlineWidthDpSetting = LocalPhotoWallpaperOutlineWidthDp.current
     val photoPillStrength =
-            (outlineWidthDpSetting / PhotoWallpaperOutlineWidthDp.MAX).coerceIn(0f, 1f)
+        (outlineWidthDpSetting / PhotoWallpaperOutlineWidthDp.MAX).coerceIn(0f, 1f)
     val photoPillAlpha = 0.14f + 0.68f * photoPillStrength
     val photoPillPaddingPx =
-            remember(outlineWidthDpSetting, density) {
-                with(density) { (3f + 10f * photoPillStrength).dp.toPx() }
-            }
+        remember(outlineWidthDpSetting, density) {
+            with(density) { (3f + 10f * photoPillStrength).dp.toPx() }
+        }
 
     Box(
-            modifier =
-                    modifier.size(scaledSize)
-                            .graphicsLayer { clip = false }
-                            .drawBehind {
-                                if (outlined && outlineWidthDpSetting > 0f) {
-                                    drawCircle(
-                                            color = Color.Black.copy(alpha = photoPillAlpha),
-                                            radius = size.minDimension / 2f + photoPillPaddingPx,
-                                    )
-                                }
-                            },
-            contentAlignment = Alignment.Center
+        modifier =
+            modifier.size(scaledSize)
+                .graphicsLayer { clip = false }
+                .drawBehind {
+                    if (outlined && outlineWidthDpSetting > 0f) {
+                        drawCircle(
+                            color = Color.Black.copy(alpha = photoPillAlpha),
+                            radius = size.minDimension / 2f + photoPillPaddingPx,
+                        )
+                    }
+                },
+        contentAlignment = Alignment.Center
     ) {
         if (!outlined && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             Icon(
-                    painter = painter,
-                    contentDescription = null,
-                    modifier =
-                            Modifier.fillMaxSize()
-                                    .graphicsLayer {
-                                        clip = false
-                                        scaleX = 1.04f
-                                        scaleY = 1.04f
-                                        alpha = 0.28f
-                                        renderEffect =
-                                                BlurEffect(
-                                                        blurRadiusPx * 1.35f,
-                                                        blurRadiusPx * 1.35f,
-                                                        TileMode.Decal,
-                                                )
-                                    }
-                                    .clearAndSetSemantics {},
-                    tint = haloTint,
+                painter = painter,
+                contentDescription = null,
+                modifier =
+                    Modifier.fillMaxSize()
+                        .graphicsLayer {
+                            clip = false
+                            scaleX = 1.04f
+                            scaleY = 1.04f
+                            alpha = 0.28f
+                            renderEffect =
+                                BlurEffect(
+                                    blurRadiusPx * 1.35f,
+                                    blurRadiusPx * 1.35f,
+                                    TileMode.Decal,
+                                )
+                        }
+                        .clearAndSetSemantics {},
+                tint = haloTint,
             )
             Icon(
-                    painter = painter,
-                    contentDescription = null,
-                    modifier =
-                            Modifier.fillMaxSize()
-                                    .graphicsLayer {
-                                        clip = false
-                                        scaleX = 1.12f
-                                        scaleY = 1.12f
-                                        alpha = 0.5f
-                                        renderEffect =
-                                                BlurEffect(
-                                                        blurRadiusPx * 0.72f,
-                                                        blurRadiusPx * 0.72f,
-                                                        TileMode.Decal,
-                                                )
-                                    }
-                                    .clearAndSetSemantics {},
-                    tint = haloTint,
+                painter = painter,
+                contentDescription = null,
+                modifier =
+                    Modifier.fillMaxSize()
+                        .graphicsLayer {
+                            clip = false
+                            scaleX = 1.12f
+                            scaleY = 1.12f
+                            alpha = 0.5f
+                            renderEffect =
+                                BlurEffect(
+                                    blurRadiusPx * 0.72f,
+                                    blurRadiusPx * 0.72f,
+                                    TileMode.Decal,
+                                )
+                        }
+                        .clearAndSetSemantics {},
+                tint = haloTint,
             )
         } else {
             Icon(
-                    painter = painter,
-                    contentDescription = null,
-                    modifier =
-                            Modifier.fillMaxSize()
-                                    .graphicsLayer {
-                                        clip = false
-                                        scaleX = glow.outerScale
-                                        scaleY = glow.outerScale
-                                        alpha = glow.outerAlpha
-                                    }
-                                    .clearAndSetSemantics {},
-                    tint = haloTint,
+                painter = painter,
+                contentDescription = null,
+                modifier =
+                    Modifier.fillMaxSize()
+                        .graphicsLayer {
+                            clip = false
+                            scaleX = glow.outerScale
+                            scaleY = glow.outerScale
+                            alpha = glow.outerAlpha
+                        }
+                        .clearAndSetSemantics {},
+                tint = haloTint,
             )
             Icon(
-                    painter = painter,
-                    contentDescription = null,
-                    modifier =
-                            Modifier.fillMaxSize()
-                                    .graphicsLayer {
-                                        clip = false
-                                        scaleX = glow.midScale
-                                        scaleY = glow.midScale
-                                        alpha = glow.midAlpha
-                                    }
-                                    .clearAndSetSemantics {},
-                    tint = haloTint,
+                painter = painter,
+                contentDescription = null,
+                modifier =
+                    Modifier.fillMaxSize()
+                        .graphicsLayer {
+                            clip = false
+                            scaleX = glow.midScale
+                            scaleY = glow.midScale
+                            alpha = glow.midAlpha
+                        }
+                        .clearAndSetSemantics {},
+                tint = haloTint,
             )
         }
         Icon(
-                painter = painter,
-                contentDescription = contentDescription,
-                modifier =
-                        Modifier.fillMaxSize()
-                                .graphicsLayer {
-                                    if (outlined && outlineWidthDpSetting > 0f) {
-                                        scaleX = 1.12f
-                                        scaleY = 1.12f
-                                    }
-                                },
-                tint = resolvedTint,
+            painter = painter,
+            contentDescription = contentDescription,
+            modifier =
+                Modifier.fillMaxSize()
+                    .graphicsLayer {
+                        if (outlined && outlineWidthDpSetting > 0f) {
+                            scaleX = 1.12f
+                            scaleY = 1.12f
+                        }
+                    },
+            tint = resolvedTint,
         )
     }
 }

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/components/LauncherIcon.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/components/LauncherIcon.kt
@@ -1,5 +1,6 @@
 package com.lu4p.fokuslauncher.ui.components
 
+import android.graphics.drawable.Drawable
 import android.os.Build
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -15,7 +16,9 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.BlurEffect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TileMode
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
@@ -23,12 +26,13 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.core.graphics.drawable.toBitmap
 import com.lu4p.fokuslauncher.data.model.LauncherFontScale
 import com.lu4p.fokuslauncher.data.model.PhotoWallpaperOutlineWidthDp
-import com.lu4p.fokuslauncher.ui.theme.LocalPhotoWallpaperOutlineWidthDp
 import com.lu4p.fokuslauncher.ui.theme.LauncherIconGlowSpec
 import com.lu4p.fokuslauncher.ui.theme.LocalLauncherFontScale
 import com.lu4p.fokuslauncher.ui.theme.LocalLauncherIconGlow
+import com.lu4p.fokuslauncher.ui.theme.LocalPhotoWallpaperOutlineWidthDp
 import com.lu4p.fokuslauncher.ui.theme.launcherIconDp
 
 /**
@@ -64,6 +68,83 @@ fun LauncherIcon(
 
 @Composable
 fun LauncherIcon(
+        drawable: Drawable?,
+        contentDescription: String?,
+        modifier: Modifier = Modifier,
+        tint: Color? = null,
+        iconSize: Dp = 24.dp,
+        suppressGlow: Boolean = false,
+        outlined: Boolean = false,
+) {
+    if (drawable == null) return
+    val density = LocalDensity.current
+
+    val (painter, canTint) =
+            remember(drawable, density, iconSize) {
+                val sizePx = with(density) { iconSize.toPx() }.toInt()
+
+                var finalDrawable: Drawable = drawable
+                var isAdaptive = false
+                var monochrome = false
+
+                if (drawable is android.graphics.drawable.AdaptiveIconDrawable) {
+                    isAdaptive = true
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        drawable.monochrome?.let {
+                            finalDrawable = it
+                            monochrome = true
+                        }
+                    }
+                    if (!monochrome) {
+                        finalDrawable = drawable.foreground
+                    }
+                } else if (drawable is android.graphics.drawable.VectorDrawable ||
+                                drawable.javaClass.name.contains("VectorDrawable")
+                ) {
+                    monochrome = true
+                }
+
+                val bitmap =
+                        if (isAdaptive) {
+                            // Zoom in to fill the safe zone. Adaptive icons are 108dp with a 72dp
+                            // safe zone. To fill the space better, we scale up.
+                            val scale = 1.42f
+                            val drawSize = (sizePx * scale).toInt()
+                            val bmp =
+                                    android.graphics.Bitmap.createBitmap(
+                                            sizePx,
+                                            sizePx,
+                                            android.graphics.Bitmap.Config.ARGB_8888
+                                    )
+                            val canvas = android.graphics.Canvas(bmp)
+                            val offset = (sizePx - drawSize) / 2
+                            finalDrawable.setBounds(
+                                    offset,
+                                    offset,
+                                    sizePx - offset,
+                                    sizePx - offset
+                            )
+                            finalDrawable.draw(canvas)
+                            bmp
+                        } else {
+                            finalDrawable.toBitmap(width = sizePx, height = sizePx)
+                        }
+                BitmapPainter(bitmap.asImageBitmap()) to monochrome
+            }
+
+    LauncherIcon(
+            painter = painter,
+            contentDescription = contentDescription,
+            modifier = modifier,
+            tint = if (canTint) tint else Color.Unspecified,
+            iconSize = iconSize,
+            suppressGlow = suppressGlow,
+            outlined = outlined,
+    )
+}
+
+@Composable
+fun LauncherIcon(
         painter: Painter,
         contentDescription: String?,
         modifier: Modifier = Modifier,
@@ -75,12 +156,16 @@ fun LauncherIcon(
     val glowSpec = LocalLauncherIconGlow.current
     val glow = if (suppressGlow) LauncherIconGlowSpec.None else glowSpec
     val resolvedTint =
-            tint
-                    ?: if (glow.enabled) {
-                        MaterialTheme.colorScheme.onSurface
-                    } else {
-                        LocalContentColor.current
-                    }
+            if (tint == Color.Unspecified) {
+                Color.Unspecified
+            } else {
+                tint
+                        ?: if (glow.enabled) {
+                            MaterialTheme.colorScheme.onSurface
+                        } else {
+                            LocalContentColor.current
+                        }
+            }
     val haloTint =
             if (!glow.enabled) {
                 Color.Transparent

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/components/RenameableBottomSheet.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/components/RenameableBottomSheet.kt
@@ -21,11 +21,16 @@ fun RenameableBottomSheet(
         onRename: (String) -> Unit,
         editIconContentDescription: String,
         modifier: Modifier = Modifier,
+        contentHeightFraction: Float? = null,
         textFieldTestTag: String? = null,
         editButtonTestTag: String? = null,
         content: @Composable ColumnScope.() -> Unit,
 ) {
-    FokusBottomSheet(onDismissRequest = onDismiss, modifier = modifier) {
+    FokusBottomSheet(
+            onDismissRequest = onDismiss,
+            modifier = modifier,
+            contentHeightFraction = contentHeightFraction,
+    ) {
         var renameMode by remember(renameKey) { mutableStateOf(false) }
         var renameValue by remember(renameKey) { mutableStateOf(initialLabel) }
 

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeAppMenuSheet.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeAppMenuSheet.kt
@@ -35,11 +35,18 @@ import com.lu4p.fokuslauncher.ui.components.SheetActionRow
 import com.lu4p.fokuslauncher.ui.util.categoryChipDisplayLabel
 
 /**
+ * Peek height for the home app long-press menu. Matches Material3's partially-expanded
+ * anchor (~half screen) so open height stays consistent when the sheet can expand.
+ */
+private const val APP_MENU_SHEET_HEIGHT_FRACTION = 0.5f
+
+/**
  * Bottom sheet "App menu" opened directly on long-pressing a home-screen app.
- * Occupies roughly the lower third to half of the screen.
+ * Opens at a fixed partial height; swipe up for full height when content overflows.
  *
  * Contents:
  *  - App name (with pencil icon to rename)
+ *  - App shortcuts (when available)
  *  - Remove from home screen
  *  - Home screen (edit icon) → opens the edit overlay
  *  - App info           → Android system settings
@@ -71,6 +78,7 @@ fun HomeAppMenuSheet(
         onDismiss = onDismiss,
         onRename = onRename,
         editIconContentDescription = stringResource(R.string.action_rename),
+        contentHeightFraction = APP_MENU_SHEET_HEIGHT_FRACTION,
     ) {
         if (showingCategoryPicker) {
             val options =

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeAppMenuSheet.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeAppMenuSheet.kt
@@ -1,8 +1,12 @@
 package com.lu4p.fokuslauncher.ui.home
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Launch
 import androidx.compose.material.icons.filled.Category
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
@@ -11,6 +15,7 @@ import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -22,7 +27,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.lu4p.fokuslauncher.R
+import com.lu4p.fokuslauncher.data.model.AppShortcutAction
 import com.lu4p.fokuslauncher.data.model.FavoriteApp
+import com.lu4p.fokuslauncher.ui.components.LauncherIcon
 import com.lu4p.fokuslauncher.ui.components.RenameableBottomSheet
 import com.lu4p.fokuslauncher.ui.components.SheetActionRow
 import com.lu4p.fokuslauncher.ui.util.categoryChipDisplayLabel
@@ -42,17 +49,19 @@ import com.lu4p.fokuslauncher.ui.util.categoryChipDisplayLabel
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeAppMenuSheet(
-    fav: FavoriteApp,
-    currentCategory: String,
-    categoryOptions: List<String>,
-    onDismiss: () -> Unit,
-    onRename: (String) -> Unit,
-    onSetCategory: (String) -> Unit,
-    onRemoveFromHome: () -> Unit,
-    onEditHomeScreen: () -> Unit,
-    onAppInfo: () -> Unit,
-    onHide: () -> Unit,
-    onUninstall: () -> Unit
+        fav: FavoriteApp,
+        currentCategory: String,
+        categoryOptions: List<String>,
+        shortcuts: List<AppShortcutAction>,
+        onDismiss: () -> Unit,
+        onRename: (String) -> Unit,
+        onSetCategory: (String) -> Unit,
+        onRemoveFromHome: () -> Unit,
+        onEditHomeScreen: () -> Unit,
+        onAppInfo: () -> Unit,
+        onHide: () -> Unit,
+        onUninstall: () -> Unit,
+        onShortcutClick: (AppShortcutAction) -> Unit,
 ) {
     var showingCategoryPicker by remember(fav.packageName, fav.profileKey) { mutableStateOf(false) }
     val context = LocalContext.current
@@ -95,6 +104,51 @@ fun HomeAppMenuSheet(
             return@RenameableBottomSheet
         }
 
+        shortcuts.forEach { action ->
+            SheetActionRow(
+                    label = action.actionLabel,
+                    onClick = {
+                        onShortcutClick(action)
+                        onDismiss()
+                    },
+                    leadingContent = {
+                        val icon = action.icon
+                        androidx.compose.foundation.layout.Box(
+                                contentAlignment = androidx.compose.ui.Alignment.Center,
+                                modifier =
+                                        Modifier.size(32.dp)
+                                                .background(
+                                                        MaterialTheme.colorScheme.secondaryContainer,
+                                                        androidx.compose.foundation.shape.CircleShape
+                                                )
+                        ) {
+                            if (icon != null) {
+                                LauncherIcon(
+                                        drawable = icon,
+                                        contentDescription = action.actionLabel,
+                                        iconSize = 26.dp,
+                                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                )
+                            } else {
+                                LauncherIcon(
+                                        imageVector = Icons.AutoMirrored.Filled.Launch,
+                                        contentDescription = action.actionLabel,
+                                        iconSize = 20.dp,
+                                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                )
+                            }
+                        }
+                    },
+                    testTag = "shortcut_${action.id}",
+            )
+        }
+
+        if (shortcuts.isNotEmpty()) {
+            androidx.compose.material3.HorizontalDivider(
+                    modifier = Modifier.padding(vertical = 8.dp)
+            )
+        }
+
         val actions: List<Triple<Int, ImageVector, () -> Unit>> =
                 listOf(
                         Triple(
@@ -102,8 +156,16 @@ fun HomeAppMenuSheet(
                                 Icons.Default.Category,
                                 { showingCategoryPicker = true },
                         ),
-                        Triple(R.string.action_remove_from_home, Icons.Default.Close, onRemoveFromHome),
-                        Triple(R.string.settings_nav_home_screen, Icons.Outlined.Edit, onEditHomeScreen),
+                        Triple(
+                                R.string.action_remove_from_home,
+                                Icons.Default.Close,
+                                onRemoveFromHome
+                        ),
+                        Triple(
+                                R.string.settings_nav_home_screen,
+                                Icons.Outlined.Edit,
+                                onEditHomeScreen
+                        ),
                         Triple(R.string.action_app_info, Icons.Default.Info, onAppInfo),
                         Triple(R.string.action_hide, Icons.Default.VisibilityOff, onHide),
                         Triple(R.string.action_uninstall, Icons.Default.Delete, onUninstall),

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeAppMenuSheet.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeAppMenuSheet.kt
@@ -49,56 +49,56 @@ import com.lu4p.fokuslauncher.ui.util.categoryChipDisplayLabel
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeAppMenuSheet(
-        fav: FavoriteApp,
-        currentCategory: String,
-        categoryOptions: List<String>,
-        shortcuts: List<AppShortcutAction>,
-        onDismiss: () -> Unit,
-        onRename: (String) -> Unit,
-        onSetCategory: (String) -> Unit,
-        onRemoveFromHome: () -> Unit,
-        onEditHomeScreen: () -> Unit,
-        onAppInfo: () -> Unit,
-        onHide: () -> Unit,
-        onUninstall: () -> Unit,
-        onShortcutClick: (AppShortcutAction) -> Unit,
+    fav: FavoriteApp,
+    currentCategory: String,
+    categoryOptions: List<String>,
+    shortcuts: List<AppShortcutAction>,
+    onDismiss: () -> Unit,
+    onRename: (String) -> Unit,
+    onSetCategory: (String) -> Unit,
+    onRemoveFromHome: () -> Unit,
+    onEditHomeScreen: () -> Unit,
+    onAppInfo: () -> Unit,
+    onHide: () -> Unit,
+    onUninstall: () -> Unit,
+    onShortcutClick: (AppShortcutAction) -> Unit,
 ) {
     var showingCategoryPicker by remember(fav.packageName, fav.profileKey) { mutableStateOf(false) }
     val context = LocalContext.current
     RenameableBottomSheet(
-            initialLabel = fav.label,
-            renameKey = fav.packageName,
-            onDismiss = onDismiss,
-            onRename = onRename,
-            editIconContentDescription = stringResource(R.string.action_rename),
+        initialLabel = fav.label,
+        renameKey = fav.packageName,
+        onDismiss = onDismiss,
+        onRename = onRename,
+        editIconContentDescription = stringResource(R.string.action_rename),
     ) {
         if (showingCategoryPicker) {
             val options =
-                    remember(categoryOptions, currentCategory) {
-                        (listOf("") + categoryOptions + currentCategory)
-                                .map { it.trim() }
-                                .distinctBy { it.lowercase() }
-                    }
+                remember(categoryOptions, currentCategory) {
+                    (listOf("") + categoryOptions + currentCategory)
+                        .map { it.trim() }
+                        .distinctBy { it.lowercase() }
+                }
             options.forEach { category ->
                 val selected = currentCategory.equals(category, ignoreCase = true)
                 val label =
-                        if (category.isBlank()) {
-                            stringResource(R.string.category_no_category)
-                        } else {
-                            categoryChipDisplayLabel(context, category)
-                        }
+                    if (category.isBlank()) {
+                        stringResource(R.string.category_no_category)
+                    } else {
+                        categoryChipDisplayLabel(context, category)
+                    }
                 SheetActionRow(
-                        label = label,
-                        onClick = { onSetCategory(category) },
-                        icon = if (selected) Icons.Default.Check else null,
-                        iconContentDescription = label,
-                        leadingContent =
-                                if (selected) {
-                                    null
-                                } else {
-                                    { Spacer(modifier = Modifier.width(24.dp)) }
-                                },
-                        testTag = "action_set_category_${category.ifBlank { "none" }}",
+                    label = label,
+                    onClick = { onSetCategory(category) },
+                    icon = if (selected) Icons.Default.Check else null,
+                    iconContentDescription = label,
+                    leadingContent =
+                        if (selected) {
+                            null
+                        } else {
+                            { Spacer(modifier = Modifier.width(24.dp)) }
+                        },
+                    testTag = "action_set_category_${category.ifBlank { "none" }}",
                 )
             }
             return@RenameableBottomSheet
@@ -106,84 +106,84 @@ fun HomeAppMenuSheet(
 
         shortcuts.forEach { action ->
             SheetActionRow(
-                    label = action.actionLabel,
-                    onClick = {
-                        onShortcutClick(action)
-                        onDismiss()
-                    },
-                    leadingContent = {
-                        val icon = action.icon
-                        androidx.compose.foundation.layout.Box(
-                                contentAlignment = androidx.compose.ui.Alignment.Center,
-                                modifier =
-                                        Modifier.size(32.dp)
-                                                .background(
-                                                        MaterialTheme.colorScheme.secondaryContainer,
-                                                        androidx.compose.foundation.shape.CircleShape
-                                                )
-                        ) {
-                            if (icon != null) {
-                                LauncherIcon(
-                                        drawable = icon,
-                                        contentDescription = action.actionLabel,
-                                        iconSize = 26.dp,
-                                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                label = action.actionLabel,
+                onClick = {
+                    onShortcutClick(action)
+                    onDismiss()
+                },
+                leadingContent = {
+                    val icon = action.icon
+                    androidx.compose.foundation.layout.Box(
+                        contentAlignment = androidx.compose.ui.Alignment.Center,
+                        modifier =
+                            Modifier.size(32.dp)
+                                .background(
+                                    MaterialTheme.colorScheme.secondaryContainer,
+                                    androidx.compose.foundation.shape.CircleShape
                                 )
-                            } else {
-                                LauncherIcon(
-                                        imageVector = Icons.AutoMirrored.Filled.Launch,
-                                        contentDescription = action.actionLabel,
-                                        iconSize = 20.dp,
-                                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                                )
-                            }
+                    ) {
+                        if (icon != null) {
+                            LauncherIcon(
+                                drawable = icon,
+                                contentDescription = action.actionLabel,
+                                iconSize = 26.dp,
+                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                            )
+                        } else {
+                            LauncherIcon(
+                                imageVector = Icons.AutoMirrored.Filled.Launch,
+                                contentDescription = action.actionLabel,
+                                iconSize = 20.dp,
+                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                            )
                         }
-                    },
-                    testTag = "shortcut_${action.id}",
+                    }
+                },
+                testTag = "shortcut_${action.id}",
             )
         }
 
         if (shortcuts.isNotEmpty()) {
             androidx.compose.material3.HorizontalDivider(
-                    modifier = Modifier.padding(vertical = 8.dp)
+                modifier = Modifier.padding(vertical = 8.dp)
             )
         }
 
         val actions: List<Triple<Int, ImageVector, () -> Unit>> =
-                listOf(
-                        Triple(
-                                R.string.action_set_category,
-                                Icons.Default.Category,
-                                { showingCategoryPicker = true },
-                        ),
-                        Triple(
-                                R.string.action_remove_from_home,
-                                Icons.Default.Close,
-                                onRemoveFromHome
-                        ),
-                        Triple(
-                                R.string.settings_nav_home_screen,
-                                Icons.Outlined.Edit,
-                                onEditHomeScreen
-                        ),
-                        Triple(R.string.action_app_info, Icons.Default.Info, onAppInfo),
-                        Triple(R.string.action_hide, Icons.Default.VisibilityOff, onHide),
-                        Triple(R.string.action_uninstall, Icons.Default.Delete, onUninstall),
-                )
+            listOf(
+                Triple(
+                    R.string.action_set_category,
+                    Icons.Default.Category,
+                    { showingCategoryPicker = true },
+                ),
+                Triple(
+                    R.string.action_remove_from_home,
+                    Icons.Default.Close,
+                    onRemoveFromHome
+                ),
+                Triple(
+                    R.string.settings_nav_home_screen,
+                    Icons.Outlined.Edit,
+                    onEditHomeScreen
+                ),
+                Triple(R.string.action_app_info, Icons.Default.Info, onAppInfo),
+                Triple(R.string.action_hide, Icons.Default.VisibilityOff, onHide),
+                Triple(R.string.action_uninstall, Icons.Default.Delete, onUninstall),
+            )
         actions.forEach { (labelRes, icon, action) ->
             val iconCdRes =
-                    when (labelRes) {
-                        R.string.settings_nav_home_screen -> R.string.cd_edit_home_screen
-                        else -> labelRes
-                    }
+                when (labelRes) {
+                    R.string.settings_nav_home_screen -> R.string.cd_edit_home_screen
+                    else -> labelRes
+                }
             SheetActionRow(
-                    label = stringResource(labelRes),
-                    onClick = {
-                        action()
-                        if (labelRes != R.string.action_set_category) onDismiss()
-                    },
-                    icon = icon,
-                    iconContentDescription = stringResource(iconCdRes),
+                label = stringResource(labelRes),
+                onClick = {
+                    action()
+                    if (labelRes != R.string.action_set_category) onDismiss()
+                },
+                icon = icon,
+                iconContentDescription = stringResource(iconCdRes),
             )
         }
     }

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.TouchApp
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -974,11 +973,7 @@ private fun HomeScreenLongPressSheet(
     onEditShortcuts: () -> Unit,
     onOpenSettings: () -> Unit
 ) {
-    val sheetState = rememberModalBottomSheetState()
-    FokusBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = sheetState,
-    ) {
+    FokusBottomSheet(onDismissRequest = onDismiss) {
         SheetActionRow(
             label = stringResource(R.string.settings_edit_home_screen),
             onClick = onEditHomeScreen,

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeScreen.kt
@@ -112,6 +112,7 @@ fun HomeScreen(
     val categoryOptions by viewModel.categoryOptions.collectAsStateWithLifecycle()
     val showWeatherAppPicker by viewModel.showWeatherAppPicker.collectAsStateWithLifecycle()
     val appMenuTarget by viewModel.appMenuTarget.collectAsStateWithLifecycle()
+    val appMenuShortcuts by viewModel.appMenuShortcuts.collectAsStateWithLifecycle()
     val showHomeScreenMenu by viewModel.showHomeScreenMenu.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val onFavoriteClick = viewModel::launchFavorite
@@ -179,18 +180,12 @@ fun HomeScreen(
 
     // App menu bottom sheet (opened directly on long-press)
     appMenuTarget?.let { fav ->
-        val currentCategory =
-                allInstalledApps
-                        .firstOrNull {
-                            it.packageName == fav.packageName &&
-                                    appProfileKey(it.userHandle) == fav.profileKey
-                        }
-                        ?.category
-                        .orEmpty()
+        val currentCategory = viewModel.getCategoryForFavorite(fav)
         HomeAppMenuSheet(
             fav = fav,
             currentCategory = currentCategory,
             categoryOptions = categoryOptions,
+            shortcuts = appMenuShortcuts,
             onDismiss = { viewModel.dismissAppMenu() },
             onRename = { newName -> viewModel.renameApp(fav, newName) },
             onSetCategory = { category -> viewModel.setFavoriteCategory(fav, category) },
@@ -201,7 +196,8 @@ fun HomeScreen(
             },
             onAppInfo = { viewModel.openAppInfo(fav) },
             onHide = { viewModel.hideApp(fav) },
-            onUninstall = { viewModel.uninstallApp(fav) }
+            onUninstall = { viewModel.uninstallApp(fav) },
+            onShortcutClick = { viewModel.launchAppShortcutAction(it) }
         )
     }
 

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeScreen.kt
@@ -103,7 +103,7 @@ fun HomeScreen(
     val countdownUiState by viewModel.countdownUiState.collectAsStateWithLifecycle()
     val homeExtraWidgets by viewModel.homeExtraWidgets.collectAsStateWithLifecycle()
     val notificationIndicatorUiState by
-            viewModel.notificationIndicatorUiState.collectAsStateWithLifecycle()
+        viewModel.notificationIndicatorUiState.collectAsStateWithLifecycle()
     val favorites by viewModel.favorites.collectAsStateWithLifecycle()
     val rightSideShortcuts by viewModel.rightSideShortcuts.collectAsStateWithLifecycle()
     val allInstalledApps by viewModel.allInstalledApps.collectAsStateWithLifecycle()
@@ -249,7 +249,7 @@ fun HomeScreenContent(
     countdownUiState: HomeCountdownUiState = HomeCountdownUiState(),
     homeExtraWidgets: List<HomeExtraWidgetEntry> = emptyList(),
     notificationIndicatorUiState: HomeNotificationIndicatorUiState =
-            HomeNotificationIndicatorUiState(),
+        HomeNotificationIndicatorUiState(),
     installedApps: List<AppInfo> = emptyList(),
     onLabelLongPress: (FavoriteApp) -> Unit = {},
     onHomeScreenLongPress: () -> Unit = {},
@@ -270,12 +270,12 @@ fun HomeScreenContent(
     val play = LocalSystemClickSound.current
     val noIndication = remember { MutableInteractionSource() }
     val outlineWidthDp =
-            if (uiState.usesPhotoWallpaper) uiState.photoWallpaperOutlineWidthDp else 0f
+        if (uiState.usesPhotoWallpaper) uiState.photoWallpaperOutlineWidthDp else 0f
     Box(
         modifier = modifier
-                .fillMaxSize()
-                .background(Color.Transparent)
-                .combinedClickable(
+            .fillMaxSize()
+            .background(Color.Transparent)
+            .combinedClickable(
                 indication = null,
                 interactionSource = noIndication,
                 onClick = { },
@@ -290,64 +290,64 @@ fun HomeScreenContent(
             .testTag("home_screen")
     ) {
         CompositionLocalProvider(LocalPhotoWallpaperOutlineWidthDp provides outlineWidthDp) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = 32.dp)
-                .windowInsetsPadding(WindowInsets.statusBarsIgnoringVisibility)
-                .padding(top = 48.dp)
-                .navigationBarsPadding()
-                .padding(bottom = 48.dp)
-        ) {
-            HomeWidgetsSection(
-                uiState = uiState,
-                clockUiState = clockUiState,
-            weatherUiState = weatherUiState,
-            mediaUiState = mediaUiState,
-            screenTimeUiState = screenTimeUiState,
-            worldClockUiState = worldClockUiState,
-            countdownUiState = countdownUiState,
-            homeExtraWidgets = homeExtraWidgets,
-            onClockClick = onClockClick,
-                onDateClick = onDateClick,
-                onWeatherClick = onWeatherClick,
-                onScreenTimeClick = onScreenTimeClick,
-                onMediaOpenApp = onMediaOpenApp,
-                onMediaPrevious = onMediaPrevious,
-                onMediaPlayPause = onMediaPlayPause,
-                onMediaNext = onMediaNext,
-                onMediaLike = onMediaLike,
-                onMediaSave = onMediaSave,
-                outlined = uiState.usesPhotoWallpaper,
-            )
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 32.dp)
+                    .windowInsetsPadding(WindowInsets.statusBarsIgnoringVisibility)
+                    .padding(top = 48.dp)
+                    .navigationBarsPadding()
+                    .padding(bottom = 48.dp)
+            ) {
+                HomeWidgetsSection(
+                    uiState = uiState,
+                    clockUiState = clockUiState,
+                    weatherUiState = weatherUiState,
+                    mediaUiState = mediaUiState,
+                    screenTimeUiState = screenTimeUiState,
+                    worldClockUiState = worldClockUiState,
+                    countdownUiState = countdownUiState,
+                    homeExtraWidgets = homeExtraWidgets,
+                    onClockClick = onClockClick,
+                    onDateClick = onDateClick,
+                    onWeatherClick = onWeatherClick,
+                    onScreenTimeClick = onScreenTimeClick,
+                    onMediaOpenApp = onMediaOpenApp,
+                    onMediaPrevious = onMediaPrevious,
+                    onMediaPlayPause = onMediaPlayPause,
+                    onMediaNext = onMediaNext,
+                    onMediaLike = onMediaLike,
+                    onMediaSave = onMediaSave,
+                    outlined = uiState.usesPhotoWallpaper,
+                )
 
-            Spacer(modifier = Modifier.weight(1f))
-
-            HomeFavoritesSection(
-                homeAlignment = uiState.homeAlignment,
-                favorites = favorites,
-                installedApps = installedApps,
-                rightSideShortcuts = rightSideShortcuts,
-                profileDisplayNameOverrides = profileDisplayNameOverrides,
-                launcherFontScale = uiState.launcherFontScale,
-                outlined = uiState.usesPhotoWallpaper,
-                notificationIndicatorUiState = notificationIndicatorUiState,
-                onLabelClick = onLabelClick,
-                onLabelLongPress = onLabelLongPress,
-                onIconClick = onIconClick
-            )
-
-            if (uiState.homeAlignment == HomeAlignment.MIDDLE) {
                 Spacer(modifier = Modifier.weight(1f))
-            } else {
-                Spacer(modifier = Modifier.height(4.dp))
-            }
-        }
 
-        HomeDefaultLauncherBanner(
-            isDefaultLauncher = uiState.isDefaultLauncher,
-            onSetDefaultLauncher = onSetDefaultLauncher
-        )
+                HomeFavoritesSection(
+                    homeAlignment = uiState.homeAlignment,
+                    favorites = favorites,
+                    installedApps = installedApps,
+                    rightSideShortcuts = rightSideShortcuts,
+                    profileDisplayNameOverrides = profileDisplayNameOverrides,
+                    launcherFontScale = uiState.launcherFontScale,
+                    outlined = uiState.usesPhotoWallpaper,
+                    notificationIndicatorUiState = notificationIndicatorUiState,
+                    onLabelClick = onLabelClick,
+                    onLabelLongPress = onLabelLongPress,
+                    onIconClick = onIconClick
+                )
+
+                if (uiState.homeAlignment == HomeAlignment.MIDDLE) {
+                    Spacer(modifier = Modifier.weight(1f))
+                } else {
+                    Spacer(modifier = Modifier.height(4.dp))
+                }
+            }
+
+            HomeDefaultLauncherBanner(
+                isDefaultLauncher = uiState.isDefaultLauncher,
+                onSetDefaultLauncher = onSetDefaultLauncher
+            )
         }
     }
 }
@@ -367,97 +367,97 @@ private fun rememberTitleMediumRowHeight(extra: Dp = 8.dp): Dp {
  */
 @Composable
 private fun HomeClockWeatherHeader(
-        clockUiState: HomeClockUiState,
-        weatherUiState: HomeWeatherUiState,
-        screenTimeUiState: HomeScreenTimeUiState,
-        showWeather: Boolean,
-        onClockClick: () -> Unit,
-        onWeatherClick: () -> Unit,
-        onScreenTimeClick: () -> Unit,
-        outlined: Boolean,
+    clockUiState: HomeClockUiState,
+    weatherUiState: HomeWeatherUiState,
+    screenTimeUiState: HomeScreenTimeUiState,
+    showWeather: Boolean,
+    onClockClick: () -> Unit,
+    onWeatherClick: () -> Unit,
+    onScreenTimeClick: () -> Unit,
+    outlined: Boolean,
 ) {
     val density = LocalDensity.current
     val clockStyle = MaterialTheme.typography.displayLarge
     val weatherTopPad =
-            remember(clockStyle, density.density, density.fontScale) {
-                val lead =
-                        ((clockStyle.lineHeight.value - clockStyle.fontSize.value) / 2f)
-                                .coerceAtLeast(0f)
-                with(density) { lead.sp.toDp() }
-            }
+        remember(clockStyle, density.density, density.fontScale) {
+            val lead =
+                ((clockStyle.lineHeight.value - clockStyle.fontSize.value) / 2f)
+                    .coerceAtLeast(0f)
+            with(density) { lead.sp.toDp() }
+        }
     val launcherScale =
-            LocalLauncherFontScale.current.coerceIn(LauncherFontScale.MIN, LauncherFontScale.MAX)
+        LocalLauncherFontScale.current.coerceIn(LauncherFontScale.MIN, LauncherFontScale.MAX)
     // Use padding (not offset): offset does not change layout height, so the header Box and
     // parents can clip or resolve hits as if the weather were still at y=0.
     val weatherLowerInset =
-            remember(density.density, density.fontScale, launcherScale) {
-                with(density) { (10f * launcherScale).sp.toDp() } + 8.dp
-            }
+        remember(density.density, density.fontScale, launcherScale) {
+            with(density) { (10f * launcherScale).sp.toDp() } + 8.dp
+        }
     val weatherRowHeight = rememberTitleMediumRowHeight()
     val weatherTop = weatherTopPad + weatherLowerInset
     val screenTimeTop =
-            weatherTop + if (showWeather) weatherRowHeight + 4.dp else 0.dp
+        weatherTop + if (showWeather) weatherRowHeight + 4.dp else 0.dp
     Box(modifier = Modifier.fillMaxWidth()) {
         if (showWeather) {
             WeatherWidget(
-                    weather = weatherUiState.weather,
-                    useFahrenheit = weatherUiState.weatherUseFahrenheit,
-                    prominent = false,
-                    outlined = outlined,
-                    onClick = onWeatherClick,
-                    modifier =
-                            Modifier.align(Alignment.TopEnd)
-                                    .padding(top = weatherTop),
+                weather = weatherUiState.weather,
+                useFahrenheit = weatherUiState.weatherUseFahrenheit,
+                prominent = false,
+                outlined = outlined,
+                onClick = onWeatherClick,
+                modifier =
+                    Modifier.align(Alignment.TopEnd)
+                        .padding(top = weatherTop),
             )
         }
         if (screenTimeUiState.showWidget) {
             ScreenTimeWidget(
-                    durationText = screenTimeUiState.durationText.orEmpty(),
-                    outlined = outlined,
-                    onClick = onScreenTimeClick,
-                    modifier =
-                            Modifier.align(Alignment.TopEnd)
-                                    .offset(y = screenTimeTop),
+                durationText = screenTimeUiState.durationText.orEmpty(),
+                outlined = outlined,
+                onClick = onScreenTimeClick,
+                modifier =
+                    Modifier.align(Alignment.TopEnd)
+                        .offset(y = screenTimeTop),
             )
         }
         Column(
-                modifier = Modifier.align(Alignment.TopStart),
+            modifier = Modifier.align(Alignment.TopStart),
         ) {
             ClockWidget(
-                    time = clockUiState.currentTime,
-                    is24HourFormat = clockUiState.is24HourFormat,
-                    outlined = outlined,
-                    onClick = onClockClick,
-                    modifier = Modifier.testTag("clock_widget"),
+                time = clockUiState.currentTime,
+                is24HourFormat = clockUiState.is24HourFormat,
+                outlined = outlined,
+                onClick = onClockClick,
+                modifier = Modifier.testTag("clock_widget"),
             )
             clockUiState.nextAlarm?.let { alarm ->
                 Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier =
-                                Modifier.padding(top = 4.dp)
-                                        .clickableNoRippleWithSystemSound(onClick = onClockClick)
-                                        .testTag("next_alarm_widget"),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier =
+                        Modifier.padding(top = 4.dp)
+                            .clickableNoRippleWithSystemSound(onClick = onClockClick)
+                            .testTag("next_alarm_widget"),
                 ) {
                     LauncherIcon(
-                            imageVector = MinimalIcons.iconFor("alarm"),
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onBackground,
-                            iconSize = 14.dp,
-                            outlined = outlined,
+                        imageVector = MinimalIcons.iconFor("alarm"),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onBackground,
+                        iconSize = 14.dp,
+                        outlined = outlined,
                     )
                     Spacer(Modifier.width(6.dp))
                     if (outlined) {
                         OutlinedText(
-                                text = alarm,
-                                style = MaterialTheme.typography.labelMedium,
-                                color = MaterialTheme.colorScheme.onBackground,
-                                outlineWidth = 1.5f,
+                            text = alarm,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onBackground,
+                            outlineWidth = 1.5f,
                         )
                     } else {
                         Text(
-                                text = alarm,
-                                style = MaterialTheme.typography.labelMedium,
-                                color = MaterialTheme.colorScheme.onBackground,
+                            text = alarm,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onBackground,
                         )
                     }
                 }
@@ -496,43 +496,43 @@ private fun HomeWidgetsSection(
     when {
         showClock -> {
             HomeClockWeatherHeader(
-                    clockUiState = clockUiState,
-                    weatherUiState = weatherUiState,
-                    screenTimeUiState = screenTimeUiState,
-                    showWeather = showWeather,
-                    onClockClick = onClockClick,
-                    onWeatherClick = onWeatherClick,
-                    onScreenTimeClick = onScreenTimeClick,
-                    outlined = outlined,
+                clockUiState = clockUiState,
+                weatherUiState = weatherUiState,
+                screenTimeUiState = screenTimeUiState,
+                showWeather = showWeather,
+                onClockClick = onClockClick,
+                onWeatherClick = onWeatherClick,
+                onScreenTimeClick = onScreenTimeClick,
+                outlined = outlined,
             )
         }
         showWeather || screenTimeUiState.showWidget -> {
             Box(modifier = Modifier.fillMaxWidth()) {
                 if (showWeather) {
                     WeatherWidget(
-                            weather = weatherUiState.weather,
-                            useFahrenheit = weatherUiState.weatherUseFahrenheit,
-                            prominent = false,
-                            outlined = outlined,
-                            onClick = onWeatherClick,
-                            modifier = Modifier.align(Alignment.TopEnd),
+                        weather = weatherUiState.weather,
+                        useFahrenheit = weatherUiState.weatherUseFahrenheit,
+                        prominent = false,
+                        outlined = outlined,
+                        onClick = onWeatherClick,
+                        modifier = Modifier.align(Alignment.TopEnd),
                     )
                 }
                 if (screenTimeUiState.showWidget) {
                     ScreenTimeWidget(
-                            durationText = screenTimeUiState.durationText.orEmpty(),
-                            outlined = outlined,
-                            onClick = onScreenTimeClick,
-                            modifier =
-                                    Modifier.align(Alignment.TopEnd)
-                                            .offset(
-                                                    y =
-                                                            if (showWeather) {
-                                                                weatherRowHeight + 4.dp
-                                                            } else {
-                                                                0.dp
-                                                            },
-                                            ),
+                        durationText = screenTimeUiState.durationText.orEmpty(),
+                        outlined = outlined,
+                        onClick = onScreenTimeClick,
+                        modifier =
+                            Modifier.align(Alignment.TopEnd)
+                                .offset(
+                                    y =
+                                        if (showWeather) {
+                                            weatherRowHeight + 4.dp
+                                        } else {
+                                            0.dp
+                                        },
+                                ),
                     )
                 }
             }
@@ -541,59 +541,59 @@ private fun HomeWidgetsSection(
 
     if (showDateOrBattery) {
         DateBatteryRow(
-                date = clockUiState.currentDate,
-                batteryPercent = clockUiState.batteryPercent,
-                isCharging = clockUiState.isCharging,
-                showDate = uiState.showHomeDate,
-                showBattery = uiState.showHomeBattery,
-                outlined = outlined,
-                onDateClick = onDateClick,
-                modifier =
-                        Modifier.fillMaxWidth()
-                                .padding(top = if (showClock) 8.dp else 0.dp)
-                                .testTag("date_battery_row"),
+            date = clockUiState.currentDate,
+            batteryPercent = clockUiState.batteryPercent,
+            isCharging = clockUiState.isCharging,
+            showDate = uiState.showHomeDate,
+            showBattery = uiState.showHomeBattery,
+            outlined = outlined,
+            onDateClick = onDateClick,
+            modifier =
+                Modifier.fillMaxWidth()
+                    .padding(top = if (showClock) 8.dp else 0.dp)
+                    .testTag("date_battery_row"),
         )
     }
 
     val belowHeaderTopPad =
-            if (showDateOrBattery || showClock || showWeather || screenTimeUiState.showWidget) {
-                8.dp
-            } else {
-                0.dp
-            }
+        if (showDateOrBattery || showClock || showWeather || screenTimeUiState.showWidget) {
+            8.dp
+        } else {
+            0.dp
+        }
     // A bit of air under the date line so extras don't sit flush against it.
     val extrasTopPad = if (showDateOrBattery) 8.dp else belowHeaderTopPad
     var nextTopPad = belowHeaderTopPad
 
     val extraChips =
-            remember(homeExtraWidgets, worldClockUiState, countdownUiState) {
-                homeExtraWidgets.mapNotNull { entry ->
-                    when (entry) {
-                        is HomeExtraWidgetEntry.WorldClock ->
-                                worldClockUiState.citiesById[entry.cityId]?.let {
-                                    HomeExtraChipUi.WorldClock(it)
-                                }
-                        is HomeExtraWidgetEntry.Countdown ->
-                                countdownUiState.eventsById[entry.eventId]?.let { event ->
-                                    if (event.title.isNotBlank() &&
-                                                    event.remainingText.isNotBlank()
-                                    ) {
-                                        HomeExtraChipUi.Countdown(
-                                                event.title,
-                                                event.remainingText,
-                                        )
-                                    } else {
-                                        null
-                                    }
-                                }
-                    }
+        remember(homeExtraWidgets, worldClockUiState, countdownUiState) {
+            homeExtraWidgets.mapNotNull { entry ->
+                when (entry) {
+                    is HomeExtraWidgetEntry.WorldClock ->
+                        worldClockUiState.citiesById[entry.cityId]?.let {
+                            HomeExtraChipUi.WorldClock(it)
+                        }
+                    is HomeExtraWidgetEntry.Countdown ->
+                        countdownUiState.eventsById[entry.eventId]?.let { event ->
+                            if (event.title.isNotBlank() &&
+                                event.remainingText.isNotBlank()
+                            ) {
+                                HomeExtraChipUi.Countdown(
+                                    event.title,
+                                    event.remainingText,
+                                )
+                            } else {
+                                null
+                            }
+                        }
                 }
             }
+        }
     if (extraChips.isNotEmpty()) {
         HomeExtraChipsRow(
-                chips = extraChips,
-                outlined = outlined,
-                modifier = Modifier.fillMaxWidth().padding(top = extrasTopPad),
+            chips = extraChips,
+            outlined = outlined,
+            modifier = Modifier.fillMaxWidth().padding(top = extrasTopPad),
         )
         nextTopPad = 8.dp
     } else {
@@ -603,22 +603,22 @@ private fun HomeWidgetsSection(
     val playback = mediaUiState.playback
     if (mediaUiState.showWidget && playback != null) {
         MediaWidget(
-                title = playback.title,
-                artist = playback.artist,
-                isPlaying = playback.isPlaying,
-                isBuffering = playback.isBuffering,
-                canSkipToPrevious = playback.canSkipToPrevious,
-                canSkipToNext = playback.canSkipToNext,
-                like = playback.like,
-                save = playback.save,
-                outlined = outlined,
-                onOpenApp = onMediaOpenApp,
-                onLike = onMediaLike,
-                onPrevious = onMediaPrevious,
-                onPlayPause = onMediaPlayPause,
-                onNext = onMediaNext,
-                onSave = onMediaSave,
-                modifier = Modifier.fillMaxWidth().padding(top = nextTopPad),
+            title = playback.title,
+            artist = playback.artist,
+            isPlaying = playback.isPlaying,
+            isBuffering = playback.isBuffering,
+            canSkipToPrevious = playback.canSkipToPrevious,
+            canSkipToNext = playback.canSkipToNext,
+            like = playback.like,
+            save = playback.save,
+            outlined = outlined,
+            onOpenApp = onMediaOpenApp,
+            onLike = onMediaLike,
+            onPrevious = onMediaPrevious,
+            onPlayPause = onMediaPlayPause,
+            onNext = onMediaNext,
+            onSave = onMediaSave,
+            modifier = Modifier.fillMaxWidth().padding(top = nextTopPad),
         )
     }
 }
@@ -634,7 +634,7 @@ private fun FavoritesList(
     modifier: Modifier = Modifier,
     outlined: Boolean = false,
     notificationIndicatorUiState: HomeNotificationIndicatorUiState =
-            HomeNotificationIndicatorUiState(),
+        HomeNotificationIndicatorUiState(),
 ) {
     Column(
         modifier = modifier,
@@ -673,12 +673,12 @@ private fun ShortcutIconsColumn(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         RightShortcutIcons(
-                shortcuts = shortcuts,
-                onIconClick = onIconClick,
-                iconSize = iconSize,
-                touchTargetSize = touchTargetSize,
-                iconAlignment = iconAlignment,
-                outlined = outlined,
+            shortcuts = shortcuts,
+            onIconClick = onIconClick,
+            iconSize = iconSize,
+            touchTargetSize = touchTargetSize,
+            iconAlignment = iconAlignment,
+            outlined = outlined,
         )
     }
 }
@@ -693,22 +693,22 @@ private fun HomeFavoritesSection(
     launcherFontScale: Float,
     outlined: Boolean,
     notificationIndicatorUiState: HomeNotificationIndicatorUiState =
-            HomeNotificationIndicatorUiState(),
+        HomeNotificationIndicatorUiState(),
     onLabelClick: (FavoriteApp) -> Unit,
     onLabelLongPress: (FavoriteApp) -> Unit,
     onIconClick: (HomeShortcut) -> Unit,
 ) {
     val sc =
-            launcherFontScale.coerceIn(LauncherFontScale.MIN, LauncherFontScale.MAX)
+        launcherFontScale.coerceIn(LauncherFontScale.MIN, LauncherFontScale.MAX)
     // Base dp only: [LauncherIcon] applies [launcherIconDp] so shortcut size tracks font scale once.
     val shortcutIconSize = 24.dp
     val shortcutTouchTargetSize = (48f * sc).dp
     val backdropStrength =
-            if (outlined) {
-                (LocalPhotoWallpaperOutlineWidthDp.current / 100f).coerceIn(0f, 1f)
-            } else {
-                0f
-            }
+        if (outlined) {
+            (LocalPhotoWallpaperOutlineWidthDp.current / 100f).coerceIn(0f, 1f)
+        } else {
+            0f
+        }
     val shortcutIconSpacing = ((8f + 16f * backdropStrength) * sc).dp
     val shortcutGutter = (24f * sc).dp
     val shortcutRowTopSpacer = (20f * sc).dp
@@ -739,12 +739,12 @@ private fun HomeFavoritesSection(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         RightShortcutIcons(
-                                shortcuts = rightSideShortcuts,
-                                onIconClick = onIconClick,
-                                iconSize = shortcutIconSize,
-                                touchTargetSize = shortcutTouchTargetSize,
-                                iconAlignment = Alignment.Center,
-                                outlined = outlined,
+                            shortcuts = rightSideShortcuts,
+                            onIconClick = onIconClick,
+                            iconSize = shortcutIconSize,
+                            touchTargetSize = shortcutTouchTargetSize,
+                            iconAlignment = Alignment.Center,
+                            outlined = outlined,
                         )
                     }
                 }
@@ -752,41 +752,41 @@ private fun HomeFavoritesSection(
 
         HomeAlignment.LEFT, HomeAlignment.RIGHT -> {
             val favAlign =
-                    if (homeAlignment == HomeAlignment.LEFT) Alignment.Start else Alignment.End
+                if (homeAlignment == HomeAlignment.LEFT) Alignment.Start else Alignment.End
             Row(
-                    modifier = listModifier,
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.Bottom,
+                modifier = listModifier,
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.Bottom,
             ) {
                 val favs: @Composable () -> Unit = {
                     FavoritesList(
-                            favorites = favorites,
-                            installedApps = installedApps,
-                            profileDisplayNameOverrides = profileDisplayNameOverrides,
-                            horizontalAlignment = favAlign,
-                            onLabelClick = onLabelClick,
-                            onLabelLongPress = onLabelLongPress,
-                            modifier = Modifier.weight(1f),
-                            outlined = outlined,
-                            notificationIndicatorUiState = notificationIndicatorUiState,
+                        favorites = favorites,
+                        installedApps = installedApps,
+                        profileDisplayNameOverrides = profileDisplayNameOverrides,
+                        horizontalAlignment = favAlign,
+                        onLabelClick = onLabelClick,
+                        onLabelLongPress = onLabelLongPress,
+                        modifier = Modifier.weight(1f),
+                        outlined = outlined,
+                        notificationIndicatorUiState = notificationIndicatorUiState,
                     )
                 }
                 val icons: @Composable () -> Unit = {
                     val iconAlignment =
-                            if (homeAlignment == HomeAlignment.LEFT) {
-                                Alignment.CenterEnd
-                            } else {
-                                Alignment.CenterStart
-                            }
+                        if (homeAlignment == HomeAlignment.LEFT) {
+                            Alignment.CenterEnd
+                        } else {
+                            Alignment.CenterStart
+                        }
                     ShortcutIconsColumn(
-                            shortcuts = rightSideShortcuts,
-                            onIconClick = onIconClick,
-                            iconSize = shortcutIconSize,
-                            touchTargetSize = shortcutTouchTargetSize,
-                            iconAlignment = iconAlignment,
-                            verticalSpacing = shortcutIconSpacing,
-                            modifier = Modifier.offset(y = (-8).dp),
-                            outlined = outlined,
+                        shortcuts = rightSideShortcuts,
+                        onIconClick = onIconClick,
+                        iconSize = shortcutIconSize,
+                        touchTargetSize = shortcutTouchTargetSize,
+                        iconAlignment = iconAlignment,
+                        verticalSpacing = shortcutIconSpacing,
+                        modifier = Modifier.offset(y = (-8).dp),
+                        outlined = outlined,
                     )
                 }
                 if (homeAlignment == HomeAlignment.LEFT) {
@@ -814,18 +814,18 @@ private fun RightShortcutIcons(
 ) {
     shortcuts.reversed().forEachIndexed { index, shortcut ->
         Box(
-                modifier =
-                        Modifier.size(touchTargetSize)
-                                .clickableNoRippleWithSystemSound { onIconClick(shortcut) }
-                                .testTag("right_shortcut_icon_$index"),
-                contentAlignment = iconAlignment,
+            modifier =
+                Modifier.size(touchTargetSize)
+                    .clickableNoRippleWithSystemSound { onIconClick(shortcut) }
+                    .testTag("right_shortcut_icon_$index"),
+            contentAlignment = iconAlignment,
         ) {
             LauncherIcon(
-                    imageVector = MinimalIcons.iconFor(shortcut.iconName),
-                    contentDescription = stringResource(R.string.cd_shortcut_icon),
-                    tint = MaterialTheme.colorScheme.onBackground,
-                    iconSize = iconSize,
-                    outlined = outlined,
+                imageVector = MinimalIcons.iconFor(shortcut.iconName),
+                contentDescription = stringResource(R.string.cd_shortcut_icon),
+                tint = MaterialTheme.colorScheme.onBackground,
+                iconSize = iconSize,
+                outlined = outlined,
             )
         }
     }
@@ -859,98 +859,98 @@ private fun BoxScope.HomeDefaultLauncherBanner(
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun FavoriteAppItem(
-        fav: FavoriteApp,
-        installedApps: List<AppInfo>,
-        profileDisplayNameOverrides: Map<String, String>,
-        onClick: () -> Unit,
-        onLongPress: () -> Unit,
-        horizontalAlignment: Alignment.Horizontal,
-        outlined: Boolean,
-        notificationIndicatorUiState: HomeNotificationIndicatorUiState =
-                HomeNotificationIndicatorUiState(),
+    fav: FavoriteApp,
+    installedApps: List<AppInfo>,
+    profileDisplayNameOverrides: Map<String, String>,
+    onClick: () -> Unit,
+    onLongPress: () -> Unit,
+    horizontalAlignment: Alignment.Horizontal,
+    outlined: Boolean,
+    notificationIndicatorUiState: HomeNotificationIndicatorUiState =
+        HomeNotificationIndicatorUiState(),
 ) {
     val context = LocalContext.current
     val badge =
-            remember(fav, installedApps, profileDisplayNameOverrides, context) {
-                val match =
-                        installedApps.find {
-                            it.packageName == fav.packageName &&
-                                    appProfileKey(it.userHandle) == fav.profileKey
-                        }
-                profileOriginLabelForFavorite(context, fav, match, profileDisplayNameOverrides)
-            }
+        remember(fav, installedApps, profileDisplayNameOverrides, context) {
+            val match =
+                installedApps.find {
+                    it.packageName == fav.packageName &&
+                        appProfileKey(it.userHandle) == fav.profileKey
+                }
+            profileOriginLabelForFavorite(context, fav, match, profileDisplayNameOverrides)
+        }
     val appKey = drawerOpenCountKey(fav.packageName, fav.profileKey)
     val hasNotification =
-            notificationIndicatorUiState.enabled &&
-                    appKey in notificationIndicatorUiState.appsWithNotifications
+        notificationIndicatorUiState.enabled &&
+            appKey in notificationIndicatorUiState.appsWithNotifications
     val textColor = MaterialTheme.colorScheme.onBackground
     val indicatorColor = Color(notificationIndicatorUiState.colorArgb)
     val labelColor =
-            if (hasNotification &&
-                            notificationIndicatorUiState.style ==
-                                    NotificationIndicatorStyle.COLORED_LABEL
-            ) {
-                indicatorColor
-            } else {
-                textColor
-            }
+        if (hasNotification &&
+            notificationIndicatorUiState.style ==
+                NotificationIndicatorStyle.COLORED_LABEL
+        ) {
+            indicatorColor
+        } else {
+            textColor
+        }
     val showDot =
-            hasNotification &&
-                    notificationIndicatorUiState.style == NotificationIndicatorStyle.DOT
+        hasNotification &&
+            notificationIndicatorUiState.style == NotificationIndicatorStyle.DOT
     val dotLeading = horizontalAlignment == Alignment.Start
     Column(
-            horizontalAlignment = horizontalAlignment,
-            modifier =
-                    Modifier.fillMaxWidth()
-                            .combinedClickableWithSystemSound(
-                                    indication = LocalIndication.current,
-                                    interactionSource = remember { MutableInteractionSource() },
-                                    onClick = onClick,
-                                    onLongClick = onLongPress,
-                            )
-                            .testTag("favorite_${fav.label}"),
+        horizontalAlignment = horizontalAlignment,
+        modifier =
+            Modifier.fillMaxWidth()
+                .combinedClickableWithSystemSound(
+                    indication = LocalIndication.current,
+                    interactionSource = remember { MutableInteractionSource() },
+                    onClick = onClick,
+                    onLongClick = onLongPress,
+                )
+                .testTag("favorite_${fav.label}"),
     ) {
         Box {
             if (outlined) {
                 OutlinedText(
-                        text = fav.label,
-                        style = MaterialTheme.typography.headlineMedium,
-                        color = labelColor,
+                    text = fav.label,
+                    style = MaterialTheme.typography.headlineMedium,
+                    color = labelColor,
                 )
             } else {
                 Text(
-                        text = fav.label,
-                        style = MaterialTheme.typography.headlineMedium,
-                        color = labelColor,
+                    text = fav.label,
+                    style = MaterialTheme.typography.headlineMedium,
+                    color = labelColor,
                 )
             }
             if (showDot) {
                 NotificationIndicatorDot(
-                        color = textColor,
-                        modifier =
-                                Modifier.align(
-                                                if (dotLeading) Alignment.CenterStart
-                                                else Alignment.CenterEnd
-                                        )
-                                        .offset(x = if (dotLeading) (-16).dp else 16.dp),
+                    color = textColor,
+                    modifier =
+                        Modifier.align(
+                            if (dotLeading) Alignment.CenterStart
+                            else Alignment.CenterEnd
+                        )
+                        .offset(x = if (dotLeading) (-16).dp else 16.dp),
                 )
             }
         }
         if (badge != null) {
             if (outlined) {
                 OutlinedText(
-                        text = badge,
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(top = 4.dp),
-                        outlineWidth = 1.5f,
+                    text = badge,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp),
+                    outlineWidth = 1.5f,
                 )
             } else {
                 Text(
-                        text = badge,
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(top = 4.dp),
+                    text = badge,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp),
                 )
             }
         }
@@ -960,9 +960,9 @@ private fun FavoriteAppItem(
 @Composable
 private fun NotificationIndicatorDot(color: Color, modifier: Modifier = Modifier) {
     Box(
-            modifier =
-                    modifier.size(8.dp)
-                            .background(color = color, shape = CircleShape),
+        modifier =
+            modifier.size(8.dp)
+                .background(color = color, shape = CircleShape),
     )
 }
 
@@ -979,23 +979,23 @@ private fun HomeScreenLongPressSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
     ) {
-            SheetActionRow(
-                label = stringResource(R.string.settings_edit_home_screen),
-                onClick = onEditHomeScreen,
-                icon = Icons.Default.Home,
-                iconContentDescription = stringResource(R.string.cd_edit_home_screen),
-            )
-            SheetActionRow(
-                label = stringResource(R.string.settings_edit_shortcuts),
-                onClick = onEditShortcuts,
-                icon = Icons.Filled.TouchApp,
-                iconContentDescription = stringResource(R.string.settings_edit_shortcuts),
-            )
-            SheetActionRow(
-                label = stringResource(R.string.settings_title),
-                onClick = onOpenSettings,
-                icon = Icons.Default.Settings,
-                iconContentDescription = stringResource(R.string.cd_settings),
-            )
+        SheetActionRow(
+            label = stringResource(R.string.settings_edit_home_screen),
+            onClick = onEditHomeScreen,
+            icon = Icons.Default.Home,
+            iconContentDescription = stringResource(R.string.cd_edit_home_screen),
+        )
+        SheetActionRow(
+            label = stringResource(R.string.settings_edit_shortcuts),
+            onClick = onEditShortcuts,
+            icon = Icons.Filled.TouchApp,
+            iconContentDescription = stringResource(R.string.settings_edit_shortcuts),
+        )
+        SheetActionRow(
+            label = stringResource(R.string.settings_title),
+            onClick = onOpenSettings,
+            icon = Icons.Default.Settings,
+            iconContentDescription = stringResource(R.string.cd_settings),
+        )
     }
 }

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeViewModel.kt
@@ -1689,30 +1689,30 @@ class HomeViewModel @Inject constructor(
     fun getShortcutIcon(action: AppShortcutAction) = appRepository.getShortcutIcon(action)
 
     private fun isHomeCategoryPickerReserved(category: String): Boolean =
-            category.equals(ReservedCategoryNames.ALL_APPS, ignoreCase = true) ||
-                    category.equals(ReservedCategoryNames.PRIVATE, ignoreCase = true) ||
-                    category.equals(ReservedCategoryNames.WORK, ignoreCase = true) ||
-                    category.equals(ReservedCategoryNames.UNCATEGORIZED, ignoreCase = true)
+        category.equals(ReservedCategoryNames.ALL_APPS, ignoreCase = true) ||
+            category.equals(ReservedCategoryNames.PRIVATE, ignoreCase = true) ||
+            category.equals(ReservedCategoryNames.WORK, ignoreCase = true) ||
+            category.equals(ReservedCategoryNames.UNCATEGORIZED, ignoreCase = true)
 
     private companion object {
         private val shortcutActionIconKeywordHints =
-                listOf(
-                        "music" to "music",
-                        "work" to "work",
-                        "mail" to "work",
-                        "chat" to "chat",
-                        "message" to "chat",
-                        "call" to "call",
-                        "dial" to "call",
-                        "dialer" to "call",
-                        "phone" to "call",
-                        "camera" to "camera",
-                        "photo" to "gallery",
-                        "gallery" to "gallery",
-                        "video" to "video",
-                        "map" to "map",
-                        "direction" to "map",
-                )
+            listOf(
+                "music" to "music",
+                "work" to "work",
+                "mail" to "work",
+                "chat" to "chat",
+                "message" to "chat",
+                "call" to "call",
+                "dial" to "call",
+                "dialer" to "call",
+                "phone" to "call",
+                "camera" to "camera",
+                "photo" to "gallery",
+                "gallery" to "gallery",
+                "video" to "video",
+                "map" to "map",
+                "direction" to "map",
+            )
 
         /**
          * [Intent.EXTRA_TIMEZONE] documents this key but the constant is not inlined below API 30;

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeViewModel.kt
@@ -266,6 +266,9 @@ class HomeViewModel @Inject constructor(
     private val _appMenuTarget = MutableStateFlow<FavoriteApp?>(null)
     val appMenuTarget: StateFlow<FavoriteApp?> = _appMenuTarget.asStateFlow()
 
+    private val _appMenuShortcuts = MutableStateFlow<List<AppShortcutAction>>(emptyList())
+    val appMenuShortcuts: StateFlow<List<AppShortcutAction>> = _appMenuShortcuts.asStateFlow()
+
     private val _showHomeScreenMenu = MutableStateFlow(false)
     val showHomeScreenMenu: StateFlow<Boolean> = _showHomeScreenMenu.asStateFlow()
 
@@ -544,6 +547,11 @@ class HomeViewModel @Inject constructor(
 
     fun onFavoriteLongPress(fav: FavoriteApp) {
         _appMenuTarget.value = fav
+
+        viewModelScope.launch {
+            val user = appRepository.getUserHandleForProfile(fav.profileKey) ?: Process.myUserHandle()
+            _appMenuShortcuts.value = appRepository.getShortcutsForApp(fav.packageName, user)
+        }
     }
 
     fun onHomeScreenLongPress() {
@@ -672,6 +680,7 @@ class HomeViewModel @Inject constructor(
 
     fun dismissAppMenu() {
         _appMenuTarget.value = null
+        _appMenuShortcuts.value = emptyList()
     }
 
     fun openWeatherAppPicker() {
@@ -713,6 +722,10 @@ class HomeViewModel @Inject constructor(
             }
             dismissAppMenu()
         }
+    }
+
+    fun getCategoryForFavorite(fav: FavoriteApp): String {
+        return installedAppFor(fav.packageName, fav.profileKey)?.category.orEmpty()
     }
 
     fun setFavoriteCategory(favorite: FavoriteApp, category: String) {
@@ -1627,10 +1640,12 @@ class HomeViewModel @Inject constructor(
         return true
     }
 
-    private fun installedAppFor(packageName: String, profileKey: String): AppInfo? =
-            _allInstalledApps.value.firstOrNull {
-                it.packageName == packageName && appProfileKey(it.userHandle) == profileKey
-            }
+    private fun installedAppFor(packageName: String, profileKey: String): AppInfo? {
+        val user = appRepository.getUserHandleForProfile(profileKey)
+        return _allInstalledApps.value.firstOrNull {
+            it.packageName == packageName && it.userHandle == user
+        }
+    }
 
     private fun shortcutArchivedKey(shortcut: HomeShortcut): String? =
             when (val target = shortcut.target) {
@@ -1664,6 +1679,14 @@ class HomeViewModel @Inject constructor(
 
     private fun FavoriteApp.isPhoneFavoriteSentinel(): Boolean =
             packageName == ShortcutTarget.PHONE_FAVORITE_SENTINEL_PACKAGE
+
+    fun launchAppShortcutAction(action: AppShortcutAction) {
+        val target = action.target as? ShortcutTarget.LauncherShortcut ?: return
+        val user = appRepository.getUserHandleForProfile(action.profileKey)
+        appRepository.launchLauncherShortcut(target.packageName, target.shortcutId, user)
+    }
+
+    fun getShortcutIcon(action: AppShortcutAction) = appRepository.getShortcutIcon(action)
 
     private fun isHomeCategoryPickerReserved(category: String): Boolean =
             category.equals(ReservedCategoryNames.ALL_APPS, ignoreCase = true) ||

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeViewModel.kt
@@ -550,7 +550,8 @@ class HomeViewModel @Inject constructor(
 
         viewModelScope.launch {
             val user = appRepository.getUserHandleForProfile(fav.profileKey) ?: Process.myUserHandle()
-            _appMenuShortcuts.value = appRepository.getShortcutsForApp(fav.packageName, user)
+            _appMenuShortcuts.value =
+                    appRepository.getShortcutsForApp(fav.packageName, user).take(MAX_APP_MENU_SHORTCUTS)
         }
     }
 
@@ -1695,6 +1696,9 @@ class HomeViewModel @Inject constructor(
             category.equals(ReservedCategoryNames.UNCATEGORIZED, ignoreCase = true)
 
     private companion object {
+        /** Max launcher shortcuts shown in the home long-press app menu. */
+        private const val MAX_APP_MENU_SHORTCUTS = 5
+
         private val shortcutActionIconKeywordHints =
             listOf(
                 "music" to "music",

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/ShortcutActionPickerDialog.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/ShortcutActionPickerDialog.kt
@@ -40,129 +40,129 @@ import com.lu4p.fokuslauncher.utils.containsNormalizedSearch
  */
 @Composable
 fun ShortcutActionPickerDialog(
-        allActions: List<AppShortcutAction>,
-        allApps: List<AppInfo>,
-        title: String,
-        onSelect: (AppShortcutAction) -> Unit,
-        onDismiss: () -> Unit,
-        containerColor: Color = MaterialTheme.colorScheme.surfaceVariant,
-        includeWidgetPageTarget: Boolean = false,
-        profileDisplayNameOverrides: Map<String, String> = emptyMap(),
+    allActions: List<AppShortcutAction>,
+    allApps: List<AppInfo>,
+    title: String,
+    onSelect: (AppShortcutAction) -> Unit,
+    onDismiss: () -> Unit,
+    containerColor: Color = MaterialTheme.colorScheme.surfaceVariant,
+    includeWidgetPageTarget: Boolean = false,
+    profileDisplayNameOverrides: Map<String, String> = emptyMap(),
 ) {
     SearchablePickerDialog(
-            title = title,
-            onDismiss = onDismiss,
-            containerColor = containerColor,
+        title = title,
+        onDismiss = onDismiss,
+        containerColor = containerColor,
     ) { filter, onFilterChange ->
         val context = LocalContext.current
         val filtered =
-                remember(filter, allActions) {
-                    if (filter.isBlank()) allActions
-                    else allActions.filter { it.displayLabel.containsNormalizedSearch(filter) }
-                }
+            remember(filter, allActions) {
+                if (filter.isBlank()) allActions
+                else allActions.filter { it.displayLabel.containsNormalizedSearch(filter) }
+            }
         val sections =
-                remember(filtered, allApps, context, profileDisplayNameOverrides) {
-                    groupShortcutActionsIntoProfileSections(
-                            context,
-                            filtered,
-                            allApps,
-                            profileDisplayNameOverrides,
-                    )
-                }
+            remember(filtered, allApps, context, profileDisplayNameOverrides) {
+                groupShortcutActionsIntoProfileSections(
+                    context,
+                    filtered,
+                    allApps,
+                    profileDisplayNameOverrides,
+                )
+            }
 
         OutlinedTextField(
-                value = filter,
-                onValueChange = onFilterChange,
-                label = { Text(stringResource(R.string.search)) },
-                singleLine = true,
-                modifier = Modifier.fillMaxWidth()
+            value = filter,
+            onValueChange = onFilterChange,
+            label = { Text(stringResource(R.string.search)) },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
         )
         Spacer(Modifier.height(8.dp))
         LazyColumn(
-                modifier =
-                        Modifier.fillMaxWidth().heightIn(min = 200.dp, max = 420.dp)
+            modifier =
+                Modifier.fillMaxWidth().heightIn(min = 200.dp, max = 420.dp)
         ) {
             if (includeWidgetPageTarget) {
                 item(key = "shortcut_action_widget_page") {
                     Text(
-                            text = stringResource(R.string.widget_page_shortcut_label),
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onBackground,
-                            modifier =
-                                    Modifier.fillMaxWidth()
-                                            .clickableWithSystemSound {
-                                                onSelect(
-                                                        AppShortcutAction(
-                                                                appLabel =
-                                                                        context.getString(
-                                                                                R.string.app_name
-                                                                        ),
-                                                                actionLabel =
-                                                                        context.getString(
-                                                                                R.string.widget_page_shortcut_label
-                                                                        ),
-                                                                target = ShortcutTarget.WidgetPage,
-                                                        )
-                                                )
-                                            }
-                                            .padding(vertical = 10.dp, horizontal = 8.dp),
+                        text = stringResource(R.string.widget_page_shortcut_label),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onBackground,
+                        modifier =
+                            Modifier.fillMaxWidth()
+                                .clickableWithSystemSound {
+                                    onSelect(
+                                        AppShortcutAction(
+                                            appLabel =
+                                                context.getString(
+                                                    R.string.app_name
+                                                ),
+                                            actionLabel =
+                                                context.getString(
+                                                    R.string.widget_page_shortcut_label
+                                                ),
+                                            target = ShortcutTarget.WidgetPage,
+                                        )
+                                    )
+                                }
+                                .padding(vertical = 10.dp, horizontal = 8.dp),
                     )
                 }
             }
             profileGroupedShortcutItems(
-                    sections = sections,
-                    keyPrefix = "shortcut_action_pick",
-                    horizontalPadding = 8.dp,
+                sections = sections,
+                keyPrefix = "shortcut_action_pick",
+                horizontalPadding = 8.dp,
             ) { action ->
                 val line =
-                        when {
-                            action.actionLabel == AppShortcutAction.OPEN_APP_LABEL -> action.appLabel
-                            action.target is ShortcutTarget.PhoneDial -> action.appLabel
-                            else -> action.displayLabel
-                        }
+                    when {
+                        action.actionLabel == AppShortcutAction.OPEN_APP_LABEL -> action.appLabel
+                        action.target is ShortcutTarget.PhoneDial -> action.appLabel
+                        else -> action.displayLabel
+                    }
                 Row(
-                        verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
-                        modifier =
-                                Modifier.fillMaxWidth()
-                                        .clickableWithSystemSound { onSelect(action) }
-                                        .padding(vertical = 8.dp, horizontal = 8.dp)
+                    verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .clickableWithSystemSound { onSelect(action) }
+                            .padding(vertical = 8.dp, horizontal = 8.dp)
                 ) {
                     val icon = action.icon
                     androidx.compose.foundation.layout.Box(
-                            contentAlignment = androidx.compose.ui.Alignment.Center,
-                            modifier =
-                                    Modifier.size(32.dp)
-                                            .background(
-                                                    MaterialTheme.colorScheme.secondaryContainer,
-                                                    androidx.compose.foundation.shape.CircleShape
-                                            )
+                        contentAlignment = androidx.compose.ui.Alignment.Center,
+                        modifier =
+                            Modifier.size(32.dp)
+                                .background(
+                                    MaterialTheme.colorScheme.secondaryContainer,
+                                    androidx.compose.foundation.shape.CircleShape
+                                )
                     ) {
                         if (icon != null) {
                             LauncherIcon(
-                                    drawable = icon,
-                                    contentDescription = null,
-                                    iconSize = 26.dp,
-                                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                drawable = icon,
+                                contentDescription = null,
+                                iconSize = 26.dp,
+                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
                             )
                         } else {
                             LauncherIcon(
-                                    imageVector =
-                                            if (action.target is ShortcutTarget.PhoneDial) {
-                                                Icons.Outlined.Phone
-                                            } else {
-                                                Icons.AutoMirrored.Filled.Launch
-                                            },
-                                    contentDescription = null,
-                                    iconSize = 20.dp,
-                                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                imageVector =
+                                    if (action.target is ShortcutTarget.PhoneDial) {
+                                        Icons.Outlined.Phone
+                                    } else {
+                                        Icons.AutoMirrored.Filled.Launch
+                                    },
+                                contentDescription = null,
+                                iconSize = 20.dp,
+                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
                             )
                         }
                     }
                     Spacer(modifier = Modifier.width(12.dp))
                     Text(
-                            text = line,
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onBackground,
+                        text = line,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onBackground,
                     )
                 }
             }

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/ShortcutActionPickerDialog.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/ShortcutActionPickerDialog.kt
@@ -1,11 +1,18 @@
 package com.lu4p.fokuslauncher.ui.settings
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Launch
+import androidx.compose.material.icons.outlined.Phone
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -20,6 +27,7 @@ import com.lu4p.fokuslauncher.R
 import com.lu4p.fokuslauncher.data.model.AppInfo
 import com.lu4p.fokuslauncher.data.model.AppShortcutAction
 import com.lu4p.fokuslauncher.data.model.ShortcutTarget
+import com.lu4p.fokuslauncher.ui.components.LauncherIcon
 import com.lu4p.fokuslauncher.ui.components.SearchablePickerDialog
 import com.lu4p.fokuslauncher.ui.drawer.groupShortcutActionsIntoProfileSections
 import com.lu4p.fokuslauncher.ui.drawer.profileGroupedShortcutItems
@@ -112,15 +120,51 @@ fun ShortcutActionPickerDialog(
                             action.target is ShortcutTarget.PhoneDial -> action.appLabel
                             else -> action.displayLabel
                         }
-                Text(
-                        text = line,
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onBackground,
+                Row(
+                        verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
                         modifier =
                                 Modifier.fillMaxWidth()
                                         .clickableWithSystemSound { onSelect(action) }
-                                        .padding(vertical = 10.dp, horizontal = 8.dp)
-                )
+                                        .padding(vertical = 8.dp, horizontal = 8.dp)
+                ) {
+                    val icon = action.icon
+                    androidx.compose.foundation.layout.Box(
+                            contentAlignment = androidx.compose.ui.Alignment.Center,
+                            modifier =
+                                    Modifier.size(32.dp)
+                                            .background(
+                                                    MaterialTheme.colorScheme.secondaryContainer,
+                                                    androidx.compose.foundation.shape.CircleShape
+                                            )
+                    ) {
+                        if (icon != null) {
+                            LauncherIcon(
+                                    drawable = icon,
+                                    contentDescription = null,
+                                    iconSize = 26.dp,
+                                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                            )
+                        } else {
+                            LauncherIcon(
+                                    imageVector =
+                                            if (action.target is ShortcutTarget.PhoneDial) {
+                                                Icons.Outlined.Phone
+                                            } else {
+                                                Icons.AutoMirrored.Filled.Launch
+                                            },
+                                    contentDescription = null,
+                                    iconSize = 20.dp,
+                                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                            text = line,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onBackground,
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Reason behind this change

Most launchers, including the stock, Pixel, and Xperia launchers support app shortcuts/quick actions when pressing and holding on the icon in the app library menu or the home screen. I wanted to expose much of the same functionality within Fokus Launcher for a more powerful experience and one which reduces the need for taps and menu navigation once a user gets into their apps.

## Changes

- Add support for fetching and launching Android App Shortcuts (quick actions) when long-pressing favourite apps on the home screen.
- Enhance `LauncherIcon` to support `Drawable` inputs, including modern `AdaptiveIconDrawable` and `VectorDrawable`.
- Implement "smart zoom" (1.42x scaling) for adaptive icons to eliminate excessive padding and better fill UI containers.
- Add Material You support by extracting monochrome layers on Android 13 and falling back to foreground layers for themed tinting.
- Implement smart tinting to preserve original branding colours for apps that do not provide monochrome assets (e.g., Chrome, Gmail), preventing "white blob" icons.
- Fix a profile identification bug where the primary user handle was inconsistently hashed, preventing shortcut lookups.
- Unify the visual style of the Shortcut Action Picker in settings to match the new themed circular menu icons.
- Standardise code formatting to match the project’s 4-space block indent and 8-space continuation convention.
- Clean up parameter alignment and expression-body formatting in modified UI and repository components.

## Screenshots

<img width="1344" height="2992" alt="image" src="https://github.com/user-attachments/assets/0c28daaf-d6ef-4b05-8437-cb816205e540" />
<img width="1344" height="2992" alt="image" src="https://github.com/user-attachments/assets/c1a6f8c9-bb04-45a8-87c9-a55508efb225" />
<img width="1344" height="2992" alt="image" src="https://github.com/user-attachments/assets/db62b260-f6e9-4d1f-9fb4-ecd8ec0a106e" />
<img width="1344" height="2992" alt="image" src="https://github.com/user-attachments/assets/5c669abf-ebba-4479-b574-2eede80de9ce" />
