### PR TITLE
Recover from frozen renderer after screen wake

### DIFF
--- a/app/src/main/java/com/lu4p/fokuslauncher/MainActivity.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/MainActivity.kt
@@ -29,6 +29,7 @@ import com.lu4p.fokuslauncher.ui.navigation.LauncherHomeCoordinatorViewModel
 import com.lu4p.fokuslauncher.ui.theme.FokusLauncherTheme
 import com.lu4p.fokuslauncher.ui.util.ProvideAppLocale
 import com.lu4p.fokuslauncher.ui.theme.composeFontFamilyFromStoredName
+import com.lu4p.fokuslauncher.utils.FrozenRendererRecovery
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -51,6 +52,9 @@ class MainActivity : AppCompatActivity() {
     private val launcherHomeCoordinator: LauncherHomeCoordinatorViewModel by viewModels()
 
     private var shouldShowStatusBar: Boolean = false
+
+    private val frozenRendererCheck =
+            Runnable { FrozenRendererRecovery.maybeRestartIfFrozen(this) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -141,9 +145,26 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        // AOSP can leave ViewRootImpl drawing suppressed after sleep/wake with another app on top.
+        window.decorView.removeCallbacks(frozenRendererCheck)
+        window.decorView.postDelayed(frozenRendererCheck, FrozenRendererRecovery.CHECK_DELAY_MS)
+    }
+
+    override fun onPause() {
+        window.decorView.removeCallbacks(frozenRendererCheck)
+        super.onPause()
+    }
+
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)
-        if (hasFocus) applySystemBarsAppearance()
+        if (hasFocus) {
+            applySystemBarsAppearance()
+            // Unlock / focus after sleep can land after onResume; re-check then too.
+            window.decorView.removeCallbacks(frozenRendererCheck)
+            window.decorView.postDelayed(frozenRendererCheck, FrozenRendererRecovery.CHECK_DELAY_MS)
+        }
     }
 
     private fun applySystemBarsAppearance() {

--- a/app/src/main/java/com/lu4p/fokuslauncher/utils/FrozenRendererRecovery.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/utils/FrozenRendererRecovery.kt
@@ -1,0 +1,126 @@
+package com.lu4p.fokuslauncher.utils
+
+import android.app.Activity
+import android.content.Intent
+import android.os.SystemClock
+import android.util.Log
+import android.view.Display
+import android.view.View
+
+/**
+ * Work around an AOSP [android.view.ViewRootImpl] bug where
+ * `mAttachInfo.mDisplayState` can stick at [Display.STATE_OFF] after the screen is woken by
+ * another app (alarm, call, etc.) while this activity was not the top activity.
+ *
+ * When that happens, [android.view.ViewRootImpl] skips drawing (`performDraw` returns early) so
+ * the launcher UI looks frozen while touch input still works. Soft invalidation / `recreate()`
+ * does not clear the stuck attach-info state; restarting the activity does.
+ *
+ * Same class of bug addressed by Lawnchair PR #6050.
+ */
+object FrozenRendererRecovery {
+
+    private const val TAG = "FrozenRendererRecovery"
+
+    /** Delay after [Activity.onResume] before probing attach-info (lets display settle). */
+    const val CHECK_DELAY_MS = 500L
+
+    /** Avoid restart loops if reflection / lifecycle races. */
+    const val MIN_RESTART_INTERVAL_MS = 5_000L
+
+    @Volatile
+    private var lastRestartElapsedMs: Long = 0L
+
+    /**
+     * Whether a stuck ViewRoot display state should trigger an activity restart.
+     *
+     * @param viewRootDisplayState value of `ViewRootImpl.mAttachInfo.mDisplayState`, or a negative
+     *     sentinel when unavailable
+     * @param actualDisplayState [Display.getState] for the activity's display
+     */
+    fun shouldRestartForStuckDisplayState(
+            viewRootDisplayState: Int,
+            actualDisplayState: Int,
+            nowElapsedMs: Long = SystemClock.elapsedRealtime(),
+            lastRestartElapsedMs: Long = this.lastRestartElapsedMs,
+            minRestartIntervalMs: Long = MIN_RESTART_INTERVAL_MS,
+    ): Boolean {
+        if (viewRootDisplayState != Display.STATE_OFF) return false
+        if (!isDisplayVisiblyOn(actualDisplayState)) return false
+        return nowElapsedMs - lastRestartElapsedMs >= minRestartIntervalMs
+    }
+
+    fun isDisplayVisiblyOn(displayState: Int): Boolean =
+            displayState == Display.STATE_ON || displayState == Display.STATE_ON_SUSPEND
+
+    /**
+     * Reads `ViewRootImpl.mAttachInfo.mDisplayState` via reflection.
+     * @return display state constant, or `-1` if unavailable
+     */
+    fun readViewRootDisplayState(decorView: View): Int {
+        return try {
+            val viewRootImplMethod = View::class.java.getDeclaredMethod("getViewRootImpl")
+            viewRootImplMethod.isAccessible = true
+            val viewRootImpl = viewRootImplMethod.invoke(decorView) ?: return -1
+
+            val attachInfoField = viewRootImpl.javaClass.getDeclaredField("mAttachInfo")
+            attachInfoField.isAccessible = true
+            val attachInfo = attachInfoField.get(viewRootImpl) ?: return -1
+
+            val displayStateField = attachInfo.javaClass.getDeclaredField("mDisplayState")
+            displayStateField.isAccessible = true
+            displayStateField.getInt(attachInfo)
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to read ViewRootImpl.mAttachInfo.mDisplayState", e)
+            -1
+        }
+    }
+
+    fun actualDisplayState(activity: Activity): Int {
+        val display =
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+                    activity.display
+                } else {
+                    @Suppress("DEPRECATION")
+                    activity.windowManager.defaultDisplay
+                }
+        return display?.state ?: Display.STATE_UNKNOWN
+    }
+
+    /**
+     * If the ViewRoot attach-info still reports OFF while the display is on, restart the
+     * activity so drawing resumes.
+     *
+     * @return true when a restart was started
+     */
+    fun maybeRestartIfFrozen(activity: Activity): Boolean {
+        val viewRootState = readViewRootDisplayState(activity.window.decorView)
+        val actualState = actualDisplayState(activity)
+        val now = SystemClock.elapsedRealtime()
+        if (!shouldRestartForStuckDisplayState(viewRootState, actualState, now)) {
+            return false
+        }
+        Log.w(
+                TAG,
+                "Renderer appears frozen (viewRootDisplayState=$viewRootState, " +
+                        "actualDisplayState=$actualState); restarting activity",
+        )
+        lastRestartElapsedMs = now
+        restartMainActivity(activity)
+        return true
+    }
+
+    private fun restartMainActivity(activity: Activity) {
+        val intent =
+                Intent(activity, activity.javaClass).apply {
+                    action = Intent.ACTION_MAIN
+                    addCategory(Intent.CATEGORY_HOME)
+                    addFlags(
+                            Intent.FLAG_ACTIVITY_NEW_TASK or
+                                    Intent.FLAG_ACTIVITY_CLEAR_TASK or
+                                    Intent.FLAG_ACTIVITY_NO_ANIMATION
+                    )
+                }
+        activity.startActivity(intent)
+    }
+}

--- a/app/src/test/java/com/lu4p/fokuslauncher/utils/FrozenRendererRecoveryTest.kt
+++ b/app/src/test/java/com/lu4p/fokuslauncher/utils/FrozenRendererRecoveryTest.kt
@@ -1,0 +1,94 @@
+package com.lu4p.fokuslauncher.utils
+
+import android.view.Display
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class FrozenRendererRecoveryTest {
+
+    @Test
+    fun `shouldRestart when viewRoot stuck OFF while display ON and interval elapsed`() {
+        assertTrue(
+                FrozenRendererRecovery.shouldRestartForStuckDisplayState(
+                        viewRootDisplayState = Display.STATE_OFF,
+                        actualDisplayState = Display.STATE_ON,
+                        nowElapsedMs = 10_000L,
+                        lastRestartElapsedMs = 0L,
+                )
+        )
+    }
+
+    @Test
+    fun `shouldRestart when display is ON_SUSPEND`() {
+        assertTrue(
+                FrozenRendererRecovery.shouldRestartForStuckDisplayState(
+                        viewRootDisplayState = Display.STATE_OFF,
+                        actualDisplayState = Display.STATE_ON_SUSPEND,
+                        nowElapsedMs = 10_000L,
+                        lastRestartElapsedMs = 0L,
+                )
+        )
+    }
+
+    @Test
+    fun `should not restart when viewRoot already ON`() {
+        assertFalse(
+                FrozenRendererRecovery.shouldRestartForStuckDisplayState(
+                        viewRootDisplayState = Display.STATE_ON,
+                        actualDisplayState = Display.STATE_ON,
+                        nowElapsedMs = 10_000L,
+                        lastRestartElapsedMs = 0L,
+                )
+        )
+    }
+
+    @Test
+    fun `should not restart when actual display is still OFF`() {
+        assertFalse(
+                FrozenRendererRecovery.shouldRestartForStuckDisplayState(
+                        viewRootDisplayState = Display.STATE_OFF,
+                        actualDisplayState = Display.STATE_OFF,
+                        nowElapsedMs = 10_000L,
+                        lastRestartElapsedMs = 0L,
+                )
+        )
+    }
+
+    @Test
+    fun `should not restart when viewRoot state unavailable`() {
+        assertFalse(
+                FrozenRendererRecovery.shouldRestartForStuckDisplayState(
+                        viewRootDisplayState = -1,
+                        actualDisplayState = Display.STATE_ON,
+                        nowElapsedMs = 10_000L,
+                        lastRestartElapsedMs = 0L,
+                )
+        )
+    }
+
+    @Test
+    fun `should not restart within min interval`() {
+        assertFalse(
+                FrozenRendererRecovery.shouldRestartForStuckDisplayState(
+                        viewRootDisplayState = Display.STATE_OFF,
+                        actualDisplayState = Display.STATE_ON,
+                        nowElapsedMs = 4_000L,
+                        lastRestartElapsedMs = 0L,
+                        minRestartIntervalMs = 5_000L,
+                )
+        )
+    }
+
+    @Test
+    fun `isDisplayVisiblyOn covers ON and ON_SUSPEND only`() {
+        assertTrue(FrozenRendererRecovery.isDisplayVisiblyOn(Display.STATE_ON))
+        assertTrue(FrozenRendererRecovery.isDisplayVisiblyOn(Display.STATE_ON_SUSPEND))
+        assertFalse(FrozenRendererRecovery.isDisplayVisiblyOn(Display.STATE_OFF))
+        assertFalse(FrozenRendererRecovery.isDisplayVisiblyOn(Display.STATE_DOZE))
+        assertFalse(FrozenRendererRecovery.isDisplayVisiblyOn(Display.STATE_UNKNOWN))
+    }
+}


### PR DESCRIPTION
## Summary

- Detects a stuck `ViewRootImpl` display state after screen wake.
- Restarts the activity when the physical display is visibly on.
- Adds lifecycle scheduling, restart-loop protection, and unit tests.

## Testing

- Added Robolectric coverage for display-state detection and restart throttling.
- Not run: full test suite.