### PR TITLE
Fix Settings crash from duplicate renamed-app LazyColumn keys (#184)

### DIFF
--- a/app/src/androidTest/java/com/lu4p/fokuslauncher/data/database/AppDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/lu4p/fokuslauncher/data/database/AppDatabaseMigrationTest.kt
@@ -237,4 +237,109 @@ class AppDatabaseMigrationTest {
             }
         }
     }
+
+    @Test
+    fun migrate6To7_coalescesLegacyPackageWideMetadataIntoHostRows() {
+        val dbName = "migration-test-v6-to-v7"
+        helper.createDatabase(dbName, 6).apply {
+            execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `hidden_apps` (
+                        `packageName` TEXT NOT NULL,
+                        `profileKey` TEXT NOT NULL,
+                        `launcherShortcutId` TEXT NOT NULL DEFAULT '',
+                        PRIMARY KEY(`packageName`, `profileKey`, `launcherShortcutId`)
+                    )
+                    """.trimIndent()
+            )
+            execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `renamed_apps` (
+                        `packageName` TEXT NOT NULL,
+                        `profileKey` TEXT NOT NULL,
+                        `customName` TEXT NOT NULL,
+                        `launcherShortcutId` TEXT NOT NULL DEFAULT '',
+                        PRIMARY KEY(`packageName`, `profileKey`, `launcherShortcutId`)
+                    )
+                    """.trimIndent()
+            )
+            execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `app_categories` (
+                        `packageName` TEXT NOT NULL,
+                        `profileKey` TEXT NOT NULL,
+                        `category` TEXT NOT NULL,
+                        `launcherShortcutId` TEXT NOT NULL DEFAULT '',
+                        PRIMARY KEY(`packageName`, `profileKey`, `launcherShortcutId`)
+                    )
+                    """.trimIndent()
+            )
+            execSQL(
+                    "CREATE TABLE IF NOT EXISTS `app_category_definitions` (`name` TEXT NOT NULL, `position` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`name`))"
+            )
+            execSQL(
+                    "CREATE TABLE IF NOT EXISTS `suppressed_category_definitions` (`name` TEXT NOT NULL, PRIMARY KEY(`name`))"
+            )
+            execSQL(
+                    "INSERT INTO `renamed_apps` (`packageName`, `profileKey`, `customName`, `launcherShortcutId`) VALUES ('net.thunderbird.android', '0', 'Legacy Mail', '')"
+            )
+            execSQL(
+                    "INSERT INTO `renamed_apps` (`packageName`, `profileKey`, `customName`, `launcherShortcutId`) VALUES ('net.thunderbird.android', '0', 'Host Mail', '__host__')"
+            )
+            execSQL(
+                    "INSERT INTO `renamed_apps` (`packageName`, `profileKey`, `customName`, `launcherShortcutId`) VALUES ('org.mozilla.firefox', '0', 'My Browser', '')"
+            )
+            execSQL(
+                    "INSERT INTO `hidden_apps` (`packageName`, `profileKey`, `launcherShortcutId`) VALUES ('com.example.hidden', '0', '')"
+            )
+            execSQL(
+                    "INSERT INTO `app_categories` (`packageName`, `profileKey`, `category`, `launcherShortcutId`) VALUES ('com.example.cat', '0', 'Social', '')"
+            )
+            close()
+        }
+
+        val migratedDb =
+                helper.runMigrationsAndValidate(
+                        dbName,
+                        7,
+                        true,
+                        AppModule.migration6To7,
+                )
+
+        migratedDb.use { db ->
+            db.query(
+                            "SELECT packageName, profileKey, customName, launcherShortcutId FROM renamed_apps ORDER BY packageName"
+                    )
+                    .use { cursor ->
+                        assertEquals(2, cursor.count)
+                        cursor.moveToFirst()
+                        assertEquals("net.thunderbird.android", cursor.getString(0))
+                        assertEquals("Host Mail", cursor.getString(2))
+                        assertEquals("__host__", cursor.getString(3))
+                        cursor.moveToNext()
+                        assertEquals("org.mozilla.firefox", cursor.getString(0))
+                        assertEquals("My Browser", cursor.getString(2))
+                        assertEquals("__host__", cursor.getString(3))
+                    }
+            db.query(
+                            "SELECT packageName, launcherShortcutId FROM hidden_apps"
+                    )
+                    .use { cursor ->
+                        assertEquals(1, cursor.count)
+                        cursor.moveToFirst()
+                        assertEquals("com.example.hidden", cursor.getString(0))
+                        assertEquals("__host__", cursor.getString(1))
+                    }
+            db.query(
+                            "SELECT packageName, category, launcherShortcutId FROM app_categories"
+                    )
+                    .use { cursor ->
+                        assertEquals(1, cursor.count)
+                        cursor.moveToFirst()
+                        assertEquals("com.example.cat", cursor.getString(0))
+                        assertEquals("Social", cursor.getString(1))
+                        assertEquals("__host__", cursor.getString(2))
+                    }
+        }
+    }
 }

--- a/app/src/main/java/com/lu4p/fokuslauncher/data/database/AppDatabase.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/database/AppDatabase.kt
@@ -17,7 +17,7 @@ import com.lu4p.fokuslauncher.data.database.entity.SuppressedCategoryDefinitionE
         AppCategoryDefinitionEntity::class,
         SuppressedCategoryDefinitionEntity::class,
     ],
-    version = 6,
+    version = 7,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/com/lu4p/fokuslauncher/data/model/AppInfo.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/model/AppInfo.kt
@@ -48,11 +48,26 @@ fun metadataSettingsStableKey(
 ): String {
     val base = appMetadataKey(packageName, profileKey)
     return when (launcherShortcutId) {
+        // Host and legacy package-wide rows intentionally share lookup keys so
+        // favorites/home resolution can find either via [appMetadataKey].
         LEGACY_PACKAGE_WIDE_METADATA,
         HOST_APP_METADATA_SENTINEL -> base
         else -> "$base#shortcut:$launcherShortcutId"
     }
 }
+
+/**
+ * Unique LazyColumn / list identity for metadata rows.
+ *
+ * Unlike [metadataSettingsStableKey], this keeps legacy (`""`) and host
+ * (`[HOST_APP_METADATA_SENTINEL]`) rows distinct so Compose never sees
+ * duplicate keys when both briefly coexist after a rename.
+ */
+fun metadataListItemKey(
+        packageName: String,
+        profileKey: String,
+        launcherShortcutId: String,
+): String = "${appMetadataKey(packageName, profileKey)}#meta:$launcherShortcutId"
 
 fun isAppHiddenByMetadata(app: AppInfo, hiddenApps: List<com.lu4p.fokuslauncher.data.database.entity.HiddenAppEntity>): Boolean {
     if (hiddenApps.isEmpty()) return false

--- a/app/src/main/java/com/lu4p/fokuslauncher/data/repository/AppRepository.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/repository/AppRepository.kt
@@ -40,6 +40,7 @@ import com.lu4p.fokuslauncher.data.model.ShortcutTarget
 import com.lu4p.fokuslauncher.data.model.appMetadataKey
 import com.lu4p.fokuslauncher.data.model.appProfileKey
 import com.lu4p.fokuslauncher.data.model.HOST_APP_METADATA_SENTINEL
+import com.lu4p.fokuslauncher.data.model.LEGACY_PACKAGE_WIDE_METADATA
 import com.lu4p.fokuslauncher.data.model.launcherShortcutIdForMetadata
 import com.lu4p.fokuslauncher.data.model.overlayCategory
 import com.lu4p.fokuslauncher.data.model.SystemCategoryKeys
@@ -1062,6 +1063,13 @@ constructor(
             launcherShortcutId: String = HOST_APP_METADATA_SENTINEL,
     ) {
         appDao.hideApp(HiddenAppEntity(packageName, profileKey, launcherShortcutId))
+        // Host rows supersede pre-v5 package-wide rows; drop the legacy sibling to avoid
+        // duplicate Settings list keys (legacy + host share metadataSettingsStableKey).
+        if (launcherShortcutId == HOST_APP_METADATA_SENTINEL) {
+            appDao.unhideApp(
+                    HiddenAppEntity(packageName, profileKey, LEGACY_PACKAGE_WIDE_METADATA)
+            )
+        }
     }
 
     /** Unhides an app row matching the persisted shortcut id. */
@@ -1134,6 +1142,11 @@ constructor(
                         launcherShortcutId,
                 )
         )
+        // Host rows supersede pre-v5 package-wide rows; drop the legacy sibling to avoid
+        // duplicate Settings list keys (legacy + host share metadataSettingsStableKey).
+        if (launcherShortcutId == HOST_APP_METADATA_SENTINEL) {
+            appDao.removeRename(packageName, profileKey, LEGACY_PACKAGE_WIDE_METADATA)
+        }
     }
 
     /** Renames the given installed app row (host or PWA). */
@@ -1180,6 +1193,10 @@ constructor(
                         launcherShortcutId,
                 )
         )
+        // Host rows supersede pre-v5 package-wide rows; drop the legacy sibling.
+        if (launcherShortcutId == HOST_APP_METADATA_SENTINEL) {
+            appDao.removeAppCategory(packageName, profileKey, LEGACY_PACKAGE_WIDE_METADATA)
+        }
     }
 
     /** Assigns a category to the given installed app row (host or PWA). */

--- a/app/src/main/java/com/lu4p/fokuslauncher/di/AppModule.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/di/AppModule.kt
@@ -90,6 +90,43 @@ object AppModule {
             }
         }
 
+    /**
+     * Coalesce pre-v5 package-wide metadata (`launcherShortcutId = ''`) into host rows
+     * (`'__host__'`). Leaving both caused duplicate LazyColumn keys in Settings because
+     * [com.lu4p.fokuslauncher.data.model.metadataSettingsStableKey] maps them to the same
+     * lookup key (see #184).
+     */
+    val migration6To7 =
+        object : Migration(6, 7) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                coalesceLegacyPackageWideMetadata(db, "hidden_apps")
+                coalesceLegacyPackageWideMetadata(db, "renamed_apps")
+                coalesceLegacyPackageWideMetadata(db, "app_categories")
+            }
+        }
+
+    private fun coalesceLegacyPackageWideMetadata(db: SupportSQLiteDatabase, table: String) {
+        db.query(
+                        "SELECT packageName, profileKey FROM `$table` WHERE launcherShortcutId = '__host__'"
+                )
+                .use { cursor ->
+                    val packageIndex = cursor.getColumnIndexOrThrow("packageName")
+                    val profileIndex = cursor.getColumnIndexOrThrow("profileKey")
+                    while (cursor.moveToNext()) {
+                        db.execSQL(
+                                "DELETE FROM `$table` WHERE packageName = ? AND profileKey = ? AND launcherShortcutId = ''",
+                                arrayOf(
+                                        cursor.getString(packageIndex),
+                                        cursor.getString(profileIndex),
+                                ),
+                        )
+                    }
+                }
+        db.execSQL(
+                "UPDATE `$table` SET launcherShortcutId = '__host__' WHERE launcherShortcutId = ''"
+        )
+    }
+
     val migration4To5 =
         object : Migration(4, 5) {
             override fun migrate(db: SupportSQLiteDatabase) {
@@ -256,7 +293,14 @@ object AppModule {
         context,
         AppDatabase::class.java,
         "fokus_launcher_db"
-    ).addMigrations(MIGRATION_1_2, MIGRATION_2_3, migration3To4(context), migration4To5, migration5To6).build()
+    ).addMigrations(
+            MIGRATION_1_2,
+            MIGRATION_2_3,
+            migration3To4(context),
+            migration4To5,
+            migration5To6,
+            migration6To7,
+    ).build()
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/SettingsViewModel.kt
@@ -25,6 +25,9 @@ import com.lu4p.fokuslauncher.data.model.ReservedCategoryNames
 import com.lu4p.fokuslauncher.data.model.WORLD_CLOCK_LABEL_MAX_LENGTH
 import com.lu4p.fokuslauncher.data.model.WorldClockCity
 import com.lu4p.fokuslauncher.data.model.defaultLabelForTimeZoneId
+import com.lu4p.fokuslauncher.data.model.HOST_APP_METADATA_SENTINEL
+import com.lu4p.fokuslauncher.data.model.LEGACY_PACKAGE_WIDE_METADATA
+import com.lu4p.fokuslauncher.data.model.metadataListItemKey
 import com.lu4p.fokuslauncher.data.model.metadataSettingsStableKey
 import com.lu4p.fokuslauncher.data.model.appListStableKey
 import com.lu4p.fokuslauncher.data.model.appProfileKey
@@ -158,7 +161,7 @@ data class HiddenAppInfo(
         val profileLabel: String?,
 ) {
     val stableKey: String
-        get() = metadataSettingsStableKey(packageName, profileKey, launcherShortcutId)
+        get() = metadataListItemKey(packageName, profileKey, launcherShortcutId)
 }
 
 data class RenamedAppInfo(
@@ -169,7 +172,7 @@ data class RenamedAppInfo(
         val profileLabel: String?,
 ) {
     val stableKey: String
-        get() = metadataSettingsStableKey(packageName, profileKey, launcherShortcutId)
+        get() = metadataListItemKey(packageName, profileKey, launcherShortcutId)
 }
 
 data class ArchivedAppInfo(
@@ -675,24 +678,32 @@ constructor(
             privateSpaceUnlocked: Boolean,
             privateProfileKey: String?,
             profileDisplayNameOverrides: Map<String, String>,
-            packageName: (T) -> String,
-            profileKey: (T) -> String,
-            launcherShortcutId: (T) -> String,
+            crossinline packageName: (T) -> String,
+            crossinline profileKey: (T) -> String,
+            crossinline launcherShortcutId: (T) -> String,
             transform: (T, AppInfo?, String?) -> R,
-    ): List<R> =
-            entities.mapNotNull { entity ->
+    ): List<R> {
+            // Prefer host rows when a superseded legacy package-wide row still exists.
+            val hostKeys =
+                    entities
+                            .asSequence()
+                            .filter { launcherShortcutId(it) == HOST_APP_METADATA_SENTINEL }
+                            .mapTo(HashSet()) { "${packageName(it)}|${profileKey(it)}" }
+            return entities.mapNotNull { entity ->
                 val pkg = packageName(entity)
                 val prof = profileKey(entity)
                 val shortcutId = launcherShortcutId(entity)
+                if (shortcutId == LEGACY_PACKAGE_WIDE_METADATA && "$pkg|$prof" in hostKeys) {
+                    return@mapNotNull null
+                }
                 val matchingApp =
                         installedApps.find { app ->
                             app.packageName == pkg &&
                                     appProfileKey(app.userHandle) == prof &&
                                     when (shortcutId) {
-                                        com.lu4p.fokuslauncher.data.model.HOST_APP_METADATA_SENTINEL ->
+                                        HOST_APP_METADATA_SENTINEL ->
                                                 app.launcherShortcutId == null
-                                        com.lu4p.fokuslauncher.data.model.LEGACY_PACKAGE_WIDE_METADATA ->
-                                                true
+                                        LEGACY_PACKAGE_WIDE_METADATA -> true
                                         else -> app.launcherShortcutId == shortcutId
                                     }
                         }
@@ -709,6 +720,7 @@ constructor(
                                 ),
                         )
             }
+    }
 
     private fun hiddenInfosForSettings(
             hiddenApps: List<HiddenAppEntity>,

--- a/app/src/test/java/com/lu4p/fokuslauncher/data/model/AppInfoMetadataTest.kt
+++ b/app/src/test/java/com/lu4p/fokuslauncher/data/model/AppInfoMetadataTest.kt
@@ -2,12 +2,29 @@ package com.lu4p.fokuslauncher.data.model
 
 import com.lu4p.fokuslauncher.data.database.entity.AppCategoryEntity
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 class AppInfoMetadataTest {
 
     private val browserPackage = "com.vivaldi.browser"
+
+    @Test
+    fun `metadataSettingsStableKey collapses host and legacy for lookups`() {
+        assertEquals(
+                metadataSettingsStableKey(browserPackage, "0", HOST_APP_METADATA_SENTINEL),
+                metadataSettingsStableKey(browserPackage, "0", LEGACY_PACKAGE_WIDE_METADATA),
+        )
+    }
+
+    @Test
+    fun `metadataListItemKey keeps host and legacy distinct for LazyColumn`() {
+        assertNotEquals(
+                metadataListItemKey(browserPackage, "0", HOST_APP_METADATA_SENTINEL),
+                metadataListItemKey(browserPackage, "0", LEGACY_PACKAGE_WIDE_METADATA),
+        )
+    }
 
     private fun browserHost() = AppInfo(browserPackage, "Vivaldi", null)
 

--- a/app/src/test/java/com/lu4p/fokuslauncher/data/repository/AppRepositoryTest.kt
+++ b/app/src/test/java/com/lu4p/fokuslauncher/data/repository/AppRepositoryTest.kt
@@ -22,6 +22,7 @@ import com.lu4p.fokuslauncher.data.database.entity.SuppressedCategoryDefinitionE
 import com.lu4p.fokuslauncher.data.model.AddCategoryResult
 import com.lu4p.fokuslauncher.data.model.AppInfo
 import com.lu4p.fokuslauncher.data.model.HOST_APP_METADATA_SENTINEL
+import com.lu4p.fokuslauncher.data.model.LEGACY_PACKAGE_WIDE_METADATA
 import com.lu4p.fokuslauncher.data.model.AppShortcutAction
 import com.lu4p.fokuslauncher.data.model.SystemCategoryKeys
 import com.lu4p.fokuslauncher.utils.PrivateSpaceManager
@@ -618,6 +619,9 @@ class AppRepositoryTest {
             appDao.hideApp(
                     HiddenAppEntity("com.lu4p.app1", "0", HOST_APP_METADATA_SENTINEL)
             )
+            appDao.unhideApp(
+                    HiddenAppEntity("com.lu4p.app1", "0", LEGACY_PACKAGE_WIDE_METADATA)
+            )
         }
     }
 
@@ -654,6 +658,7 @@ class AppRepositoryTest {
                             HOST_APP_METADATA_SENTINEL,
                     )
             )
+            appDao.removeRename("com.lu4p.app1", "0", LEGACY_PACKAGE_WIDE_METADATA)
         }
     }
 
@@ -672,6 +677,7 @@ class AppRepositoryTest {
                             HOST_APP_METADATA_SENTINEL,
                     )
             )
+            appDao.removeAppCategory("com.lu4p.app1", "0", LEGACY_PACKAGE_WIDE_METADATA)
         }
     }
 


### PR DESCRIPTION
## Summary

- Prevent duplicate Settings list keys when legacy and host app metadata rows coexist.
- Add a Room 6-to-7 migration that coalesces legacy package-wide metadata into host rows.
- Keep metadata list identities distinct while preserving shared lookup behavior.
- Remove superseded legacy metadata when updating host app settings.

## Testing

- Added database migration coverage for hidden apps, renamed apps, and categories.
- Added metadata key behavior unit tests.
- Updated repository tests to verify legacy metadata cleanup.