### PR TITLE
Dismiss home overlays when returning to the home screen

### DIFF
--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeViewModel.kt
@@ -563,6 +563,12 @@ class HomeViewModel @Inject constructor(
         _showHomeScreenMenu.value = false
     }
 
+    /** Dismiss home long-press sheets when the system home button is pressed. */
+    fun dismissHomeOverlays() {
+        dismissHomeScreenMenu()
+        dismissAppMenu()
+    }
+
     // ── Edit flows ──────────────────────────────────────────────────
 
     fun startEditingHomeApps() = startEditingHome(includeShortcutActions = false)

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/navigation/LauncherHomeCoordinatorViewModel.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/navigation/LauncherHomeCoordinatorViewModel.kt
@@ -2,18 +2,25 @@ package com.lu4p.fokuslauncher.ui.navigation
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import javax.inject.Inject
 
 @HiltViewModel
 class LauncherHomeCoordinatorViewModel @Inject constructor() : ViewModel() {
 
-    private val goHomeChannel = Channel<Unit>(Channel.CONFLATED)
+    private val _goHomeRequests =
+            MutableSharedFlow<Unit>(
+                    extraBufferCapacity = 1,
+                    onBufferOverflow = BufferOverflow.DROP_OLDEST,
+            )
 
-    val goHomeRequests = goHomeChannel.receiveAsFlow()
+    /** Broadcast when the system home affordance asks the launcher to return to the home surface. */
+    val goHomeRequests: SharedFlow<Unit> = _goHomeRequests.asSharedFlow()
 
     fun requestGoHome() {
-        goHomeChannel.trySend(Unit)
+        _goHomeRequests.tryEmit(Unit)
     }
 }

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/navigation/NavGraph.kt
@@ -290,6 +290,13 @@ fun FokusNavGraph(
                 val homeViewModel: HomeViewModel = hiltViewModel()
                 val lifecycleOwner = LocalLifecycleOwner.current
 
+                // Home / middle nav button: dismiss empty-space long-press menu (and app menu).
+                LaunchedEffect(launcherHomeCoordinator, homeViewModel) {
+                    launcherHomeCoordinator.goHomeRequests.collect {
+                        homeViewModel.dismissHomeOverlays()
+                    }
+                }
+
                 val swipeLeftTarget by homeViewModel.swipeLeftTarget.collectAsStateWithLifecycle()
                 val swipeRightTarget by homeViewModel.swipeRightTarget.collectAsStateWithLifecycle()
                 val systemAnimationsEnabled = rememberSystemAnimationsEnabled()

--- a/app/src/test/java/com/lu4p/fokuslauncher/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/lu4p/fokuslauncher/ui/home/HomeViewModelTest.kt
@@ -52,6 +52,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -841,5 +842,27 @@ class HomeViewModelTest {
 
         verify { LockScreenHelper.lockScreenIfPossible() }
         unmockkObject(LockScreenHelper)
+    }
+
+    @Test
+    fun `dismissHomeOverlays closes home screen long-press menu`() {
+        val viewModel = createViewModel()
+        viewModel.onHomeScreenLongPress()
+        assertTrue(viewModel.showHomeScreenMenu.value)
+
+        viewModel.dismissHomeOverlays()
+
+        assertFalse(viewModel.showHomeScreenMenu.value)
+    }
+
+    @Test
+    fun `dismissHomeOverlays closes app menu`() {
+        val viewModel = createViewModel()
+        viewModel.onFavoriteLongPress(testFavorites.first())
+        assertEquals(testFavorites.first(), viewModel.appMenuTarget.value)
+
+        viewModel.dismissHomeOverlays()
+
+        assertNull(viewModel.appMenuTarget.value)
     }
 }


### PR DESCRIPTION
## Summary
- Dismiss home long-press and app menus when the system home action is triggered.
- Broadcast home navigation requests through a shared flow.
- Add unit tests covering both overlay dismissal paths.

## Testing
- Added `HomeViewModelTest` coverage for home screen and app menu dismissal.