### PR TITLE
Filter non-badgeable notifications from indicators

### DIFF
--- a/app/src/main/java/com/lu4p/fokuslauncher/notification/NotificationIndicatorKeys.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/notification/NotificationIndicatorKeys.kt
@@ -6,21 +6,36 @@ import android.service.notification.StatusBarNotification
 import com.lu4p.fokuslauncher.data.model.appMetadataKey
 import com.lu4p.fokuslauncher.data.model.appProfileKey
 
+/**
+ * Notification flags that should not drive home/drawer indicators.
+ *
+ * Group summaries are not real alerts. Ongoing and foreground-service notifications are typically
+ * sticky keep-alives (push listeners, mail sync, media) and match what stock/Nova-style badge
+ * filtering treats as non-dot-worthy.
+ */
+private const val IGNORED_NOTIFICATION_FLAGS =
+        Notification.FLAG_GROUP_SUMMARY or
+                Notification.FLAG_ONGOING_EVENT or
+                Notification.FLAG_FOREGROUND_SERVICE
+
 /** Builds the stable package+profile key used to match home/drawer rows. */
 fun notificationAppKey(packageName: String, userHandle: UserHandle?): String =
         appMetadataKey(packageName, appProfileKey(userHandle))
 
 /**
  * Returns the app key when a notification should contribute to indicators, or null when it should
- * be ignored (group summaries, own package, blank package).
+ * be ignored (group summaries, ongoing/FGS keep-alives, suppressed badges, own package, blank
+ * package).
  */
 fun notificationAppKeyOrNull(
         packageName: String?,
         flags: Int,
         userHandle: UserHandle?,
         ownPackageName: String,
+        canShowBadge: Boolean = true,
 ): String? {
-    if (flags and Notification.FLAG_GROUP_SUMMARY != 0) return null
+    if (!canShowBadge) return null
+    if (flags and IGNORED_NOTIFICATION_FLAGS != 0) return null
     if (packageName.isNullOrBlank() || packageName == ownPackageName) return null
     return notificationAppKey(packageName, userHandle)
 }
@@ -32,23 +47,32 @@ fun notificationAppKeyOrNull(
 fun notificationAppKeyOrNull(
         sbn: StatusBarNotification,
         ownPackageName: String,
+        canShowBadge: Boolean = true,
 ): String? =
         notificationAppKeyOrNull(
                 packageName = sbn.packageName,
                 flags = sbn.notification.flags,
                 userHandle = sbn.user,
                 ownPackageName = ownPackageName,
+                canShowBadge = canShowBadge,
         )
 
-/** Builds the set of apps with active (non-ignored) notifications from a listener snapshot. */
+/**
+ * Builds the set of apps with active (non-ignored) notifications from a listener snapshot.
+ *
+ * @param canShowBadgeForKey optional lookup from [android.service.notification.NotificationListenerService.RankingMap];
+ * when null, only flag-based filtering applies.
+ */
 fun appsWithNotificationsFrom(
         notifications: Array<StatusBarNotification>?,
         ownPackageName: String,
+        canShowBadgeForKey: ((notificationKey: String) -> Boolean)? = null,
 ): Set<String> {
     if (notifications.isNullOrEmpty()) return emptySet()
     return buildSet {
         for (sbn in notifications) {
-            notificationAppKeyOrNull(sbn, ownPackageName)?.let(::add)
+            val canShowBadge = canShowBadgeForKey?.invoke(sbn.key) ?: true
+            notificationAppKeyOrNull(sbn, ownPackageName, canShowBadge)?.let(::add)
         }
     }
 }

--- a/app/src/main/java/com/lu4p/fokuslauncher/notification/NotificationIndicatorRepository.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/notification/NotificationIndicatorRepository.kt
@@ -97,8 +97,24 @@ constructor(@param:ApplicationContext private val context: Context) {
                 } catch (_: RuntimeException) {
                     null
                 }
+        val rankingMap =
+                try {
+                    service.currentRanking
+                } catch (_: SecurityException) {
+                    null
+                } catch (_: RuntimeException) {
+                    null
+                }
+        val ranking = NotificationListenerService.Ranking()
         _appsWithNotifications.value =
-                appsWithNotificationsFrom(active, context.packageName)
+                appsWithNotificationsFrom(active, context.packageName) { notificationKey ->
+                    // Fall back to flag filters alone when ranking is unavailable.
+                    if (rankingMap == null || !rankingMap.getRanking(notificationKey, ranking)) {
+                        true
+                    } else {
+                        ranking.canShowBadge()
+                    }
+                }
     }
 
     companion object {

--- a/app/src/test/java/com/lu4p/fokuslauncher/notification/NotificationIndicatorKeysTest.kt
+++ b/app/src/test/java/com/lu4p/fokuslauncher/notification/NotificationIndicatorKeysTest.kt
@@ -26,6 +26,43 @@ class NotificationIndicatorKeysTest {
     }
 
     @Test
+    fun `notificationAppKeyOrNull ignores ongoing keep-alives`() {
+        assertNull(
+                notificationAppKeyOrNull(
+                        packageName = "com.example.mail",
+                        flags = Notification.FLAG_ONGOING_EVENT,
+                        userHandle = null,
+                        ownPackageName = "com.lu4p.fokuslauncher",
+                )
+        )
+    }
+
+    @Test
+    fun `notificationAppKeyOrNull ignores foreground service notifications`() {
+        assertNull(
+                notificationAppKeyOrNull(
+                        packageName = "com.example.chat",
+                        flags = Notification.FLAG_FOREGROUND_SERVICE,
+                        userHandle = null,
+                        ownPackageName = "com.lu4p.fokuslauncher",
+                )
+        )
+    }
+
+    @Test
+    fun `notificationAppKeyOrNull ignores suppressed badges`() {
+        assertNull(
+                notificationAppKeyOrNull(
+                        packageName = "com.example.mail",
+                        flags = 0,
+                        userHandle = null,
+                        ownPackageName = "com.lu4p.fokuslauncher",
+                        canShowBadge = false,
+                )
+        )
+    }
+
+    @Test
     fun `notificationAppKeyOrNull ignores own package`() {
         assertNull(
                 notificationAppKeyOrNull(
@@ -58,6 +95,12 @@ class NotificationIndicatorKeysTest {
                         listOf(
                                 Triple("com.example.mail", 0, null),
                                 Triple("com.example.mail", Notification.FLAG_GROUP_SUMMARY, null),
+                                Triple("com.example.mail", Notification.FLAG_ONGOING_EVENT, null),
+                                Triple(
+                                        "com.example.push",
+                                        Notification.FLAG_FOREGROUND_SERVICE,
+                                        null,
+                                ),
                                 Triple(own, 0, null),
                                 Triple("com.example.chat", 0, null),
                         ),


### PR DESCRIPTION
## Summary
- Ignore ongoing, foreground-service, and group-summary notifications.
- Exclude notifications whose ranking suppresses app badges.
- Add unit coverage for the expanded filtering behavior.

## Testing
- Not run