### PR TITLE
Add opt-in air quality index to home weather

### DIFF
--- a/app/src/androidTest/java/com/lu4p/fokuslauncher/ui/home/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/lu4p/fokuslauncher/ui/home/HomeScreenTest.kt
@@ -253,6 +253,36 @@ class HomeScreenTest {
     }
 
     @Test
+    fun homeScreen_weatherWidget_showsAqiNextToTemperature() {
+        composeTestRule.setContent {
+            FokusLauncherTheme {
+                HomeScreenContent(
+                        uiState = HomeUiState(showHomeWeather = true),
+                        clockUiState = clock(),
+                        weatherUiState =
+                                HomeWeatherUiState(
+                                        weather =
+                                                WeatherData(
+                                                        temperature = 22,
+                                                        iconCode = "01d",
+                                                        aqi = 29,
+                                                ),
+                                        showWeatherWidget = true,
+                                ),
+                        favorites = testFavorites,
+                        rightSideShortcuts = testRightSideShortcuts,
+                        onLabelClick = {},
+                        onLabelLongPress = {},
+                        onIconClick = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("weather_widget").assertIsDisplayed()
+        composeTestRule.onNodeWithText("22°C · AQI 29").assertIsDisplayed()
+    }
+
+    @Test
     fun homeScreen_screenTimeWidget_showsLast24HoursTotal() {
         composeTestRule.setContent {
             FokusLauncherTheme {

--- a/app/src/main/java/com/lu4p/fokuslauncher/data/local/PreferencesManager.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/local/PreferencesManager.kt
@@ -110,6 +110,8 @@ class PreferencesManager @Inject constructor(@param:ApplicationContext private v
         private val HOME_DATE_FORMAT_STYLE_KEY = stringPreferencesKey("home_date_format_style")
         private val TEMPERATURE_UNIT_KEY = stringPreferencesKey("temperature_unit")
         private val SHOW_HOME_WEATHER_KEY = booleanPreferencesKey("show_home_weather")
+        /** Opt-in AQI next to the home weather temperature; off by default. */
+        private val SHOW_HOME_AIR_QUALITY_KEY = booleanPreferencesKey("show_home_air_quality")
         /** Show current weather next to each world-clock city on home. */
         private val SHOW_WORLD_CLOCK_WEATHER_KEY =
                 booleanPreferencesKey("show_world_clock_weather")
@@ -417,6 +419,9 @@ class PreferencesManager @Inject constructor(@param:ApplicationContext private v
 
     val showHomeWeatherFlow: Flow<Boolean> = prefFlow(SHOW_HOME_WEATHER_KEY, true)
     suspend fun setShowHomeWeather(show: Boolean) = setPref(SHOW_HOME_WEATHER_KEY, show)
+
+    val showHomeAirQualityFlow: Flow<Boolean> = prefFlow(SHOW_HOME_AIR_QUALITY_KEY, false)
+    suspend fun setShowHomeAirQuality(show: Boolean) = setPref(SHOW_HOME_AIR_QUALITY_KEY, show)
 
     val showWorldClockWeatherFlow: Flow<Boolean> = prefFlow(SHOW_WORLD_CLOCK_WEATHER_KEY, false)
     suspend fun setShowWorldClockWeather(show: Boolean) =

--- a/app/src/main/java/com/lu4p/fokuslauncher/data/model/WeatherData.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/model/WeatherData.kt
@@ -8,5 +8,11 @@ data class WeatherData(
     val description: String = "",
     /** Open-Meteo-style icon code (e.g. `01d`, `10n`) for mapping to a themed weather icon. */
     val iconCode: String = "",
+    /**
+     * Consolidated air quality index from Open-Meteo when requested (US AQI when Fahrenheit is
+     * preferred, otherwise European AQI). Null when AQI was not fetched or the air-quality call
+     * failed.
+     */
+    val aqi: Int? = null,
     val lastUpdated: Long = 0L
 )

--- a/app/src/main/java/com/lu4p/fokuslauncher/data/repository/WeatherRepository.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/repository/WeatherRepository.kt
@@ -9,6 +9,8 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.math.roundToInt
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
 
@@ -22,6 +24,7 @@ class WeatherRepository @Inject constructor() {
     companion object {
         var OPEN_METEO_BASE_URL = "https://api.open-meteo.com/v1/forecast"
         var OPEN_METEO_GEOCODING_URL = "https://geocoding-api.open-meteo.com/v1/search"
+        var OPEN_METEO_AIR_QUALITY_URL = "https://air-quality-api.open-meteo.com/v1/air-quality"
         private const val CACHE_DURATION_MS = 30 * 60 * 1000L // 30 minutes
     }
 
@@ -29,6 +32,7 @@ class WeatherRepository @Inject constructor() {
             val latE2: Int,
             val lonE2: Int,
             val useFahrenheit: Boolean,
+            val includeAqi: Boolean,
     )
 
     private val weatherCache = mutableMapOf<WeatherCacheKey, WeatherData>()
@@ -36,15 +40,22 @@ class WeatherRepository @Inject constructor() {
 
     /**
      * Fetches weather data for the given coordinates. Returns cached data if less than 30 minutes
-     * old and the requested temperature unit matches the cache for those coordinates.
+     * old and the requested temperature unit / AQI option matches the cache for those coordinates.
      *
      * @param lat Latitude
      * @param lon Longitude
      * @param useFahrenheit When true, requests and parses values in Fahrenheit per Open-Meteo.
-     * @return WeatherData or null if the fetch fails
+     * Also selects US AQI instead of European AQI when [includeAqi] is true.
+     * @param includeAqi When true, also fetches current AQI from the Open-Meteo air-quality API.
+     * @return WeatherData or null if the forecast fetch fails
      */
-    suspend fun getWeather(lat: Double, lon: Double, useFahrenheit: Boolean = false): WeatherData? {
-        val key = weatherCacheKey(lat, lon, useFahrenheit)
+    suspend fun getWeather(
+            lat: Double,
+            lon: Double,
+            useFahrenheit: Boolean = false,
+            includeAqi: Boolean = false,
+    ): WeatherData? {
+        val key = weatherCacheKey(lat, lon, useFahrenheit, includeAqi)
         synchronized(weatherCache) {
             weatherCache[key]?.let { cached ->
                 if (System.currentTimeMillis() - cached.lastUpdated < CACHE_DURATION_MS) {
@@ -53,30 +64,27 @@ class WeatherRepository @Inject constructor() {
             }
         }
 
-        val temperatureUnit = if (useFahrenheit) "fahrenheit" else "celsius"
-
         return withContext(Dispatchers.IO) {
             try {
-                val url =
-                        URL(
-                                OPEN_METEO_BASE_URL +
-                                        "?latitude=$lat" +
-                                        "&longitude=$lon" +
-                                        "&current=temperature_2m,weather_code" +
-                                        "&temperature_unit=$temperatureUnit"
-                        )
-                val connection = url.openConnection() as HttpURLConnection
-                connection.requestMethod = "GET"
-                connection.connectTimeout = 10_000
-                connection.readTimeout = 10_000
-
-                if (connection.responseCode == 200) {
-                    val response = connection.inputStream.bufferedReader().readText()
-                    val weather = parseOpenMeteoResponse(response)
-                    synchronized(weatherCache) { weatherCache[key] = weather }
-                    weather
-                } else {
-                    synchronized(weatherCache) { weatherCache[key] }
+                coroutineScope {
+                    val forecastDeferred = async { fetchCurrentForecast(lat, lon, useFahrenheit) }
+                    val aqiDeferred =
+                            if (includeAqi) {
+                                async { fetchCurrentAqi(lat, lon, useUsAqi = useFahrenheit) }
+                            } else {
+                                null
+                            }
+                    val forecast = forecastDeferred.await()
+                    if (forecast == null) {
+                        synchronized(weatherCache) { weatherCache[key] }
+                    } else {
+                        val weather =
+                                forecast.copy(
+                                        aqi = if (includeAqi) aqiDeferred?.await() else null,
+                                )
+                        synchronized(weatherCache) { weatherCache[key] = weather }
+                        weather
+                    }
                 }
             } catch (_: Exception) {
                 synchronized(weatherCache) { weatherCache[key] }
@@ -90,9 +98,10 @@ class WeatherRepository @Inject constructor() {
     suspend fun getWeatherForPlace(
             placeName: String,
             useFahrenheit: Boolean = false,
+            includeAqi: Boolean = false,
     ): WeatherData? {
         val coords = geocode(placeName) ?: return null
-        return getWeather(coords.first, coords.second, useFahrenheit)
+        return getWeather(coords.first, coords.second, useFahrenheit, includeAqi)
     }
 
     /**
@@ -132,12 +141,59 @@ class WeatherRepository @Inject constructor() {
         synchronized(geocodeCache) { geocodeCache.clear() }
     }
 
-    private fun weatherCacheKey(lat: Double, lon: Double, useFahrenheit: Boolean): WeatherCacheKey =
+    private fun weatherCacheKey(
+            lat: Double,
+            lon: Double,
+            useFahrenheit: Boolean,
+            includeAqi: Boolean,
+    ): WeatherCacheKey =
             WeatherCacheKey(
                     latE2 = (lat * 100.0).roundToInt(),
                     lonE2 = (lon * 100.0).roundToInt(),
                     useFahrenheit = useFahrenheit,
+                    includeAqi = includeAqi,
             )
+
+    private fun fetchCurrentForecast(
+            lat: Double,
+            lon: Double,
+            useFahrenheit: Boolean,
+    ): WeatherData? {
+        val temperatureUnit = if (useFahrenheit) "fahrenheit" else "celsius"
+        val url =
+                URL(
+                        OPEN_METEO_BASE_URL +
+                                "?latitude=$lat" +
+                                "&longitude=$lon" +
+                                "&current=temperature_2m,weather_code" +
+                                "&temperature_unit=$temperatureUnit"
+                )
+        val connection = url.openConnection() as HttpURLConnection
+        connection.requestMethod = "GET"
+        connection.connectTimeout = 10_000
+        connection.readTimeout = 10_000
+        if (connection.responseCode != 200) return null
+        val response = connection.inputStream.bufferedReader().readText()
+        return parseOpenMeteoResponse(response)
+    }
+
+    private fun fetchCurrentAqi(lat: Double, lon: Double, useUsAqi: Boolean): Int? {
+        val aqiField = if (useUsAqi) "us_aqi" else "european_aqi"
+        val url =
+                URL(
+                        OPEN_METEO_AIR_QUALITY_URL +
+                                "?latitude=$lat" +
+                                "&longitude=$lon" +
+                                "&current=$aqiField"
+                )
+        val connection = url.openConnection() as HttpURLConnection
+        connection.requestMethod = "GET"
+        connection.connectTimeout = 10_000
+        connection.readTimeout = 10_000
+        if (connection.responseCode != 200) return null
+        val response = connection.inputStream.bufferedReader().readText()
+        return parseAirQualityResponse(response, aqiField)
+    }
 
     private fun parseOpenMeteoResponse(json: String): WeatherData {
         val obj = JSONObject(json)
@@ -152,6 +208,12 @@ class WeatherRepository @Inject constructor() {
                 iconCode = openMeteo.iconCode,
                 lastUpdated = System.currentTimeMillis()
         )
+    }
+
+    private fun parseAirQualityResponse(json: String, aqiField: String): Int? {
+        val current = JSONObject(json).optJSONObject("current") ?: return null
+        if (!current.has(aqiField) || current.isNull(aqiField)) return null
+        return current.getDouble(aqiField).roundToInt()
     }
 
     private fun parseGeocodeResponse(json: String): Pair<Double, Double>? {

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/components/WeatherWidget.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/components/WeatherWidget.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -21,6 +22,7 @@ import com.lu4p.fokuslauncher.ui.theme.LocalPhotoWallpaperOutlineWidthDp
 
 /**
  * Compact weather widget showing temperature and a Material Symbols weather glyph.
+ * When [WeatherData.aqi] is present, the air quality index is shown next to the temperature.
  * [prominent] uses [bodyLarge] for the icon and temperature so the chip reads larger while staying
  * one line (matches [DateBatteryRow] when not prominent: both use [titleMedium]).
  */
@@ -35,6 +37,13 @@ fun WeatherWidget(
 ) {
     val suffix = if (useFahrenheit) "\u00B0F" else "\u00B0C"
     val temperatureText = weather?.let { "${it.temperature}$suffix" } ?: "--$suffix"
+    val aqi = weather?.aqi
+    val displayText =
+            if (aqi != null) {
+                stringResource(R.string.weather_with_aqi_format, temperatureText, aqi)
+            } else {
+                temperatureText
+            }
     val tempStyle =
             (if (prominent) MaterialTheme.typography.bodyLarge else MaterialTheme.typography.titleMedium)
                     .copy(fontWeight = FontWeight.SemiBold)
@@ -73,7 +82,7 @@ fun WeatherWidget(
         Spacer(modifier = Modifier.width(if (prominent) 8.dp else 4.dp))
         if (outlined && !useSharedBackdrop) {
             OutlinedText(
-                    text = temperatureText,
+                    text = displayText,
                     style = tempStyle,
                     color = textColor,
                     maxLines = 1,
@@ -81,7 +90,7 @@ fun WeatherWidget(
             )
         } else {
             Text(
-                text = temperatureText,
+                text = displayText,
                 style = tempStyle,
                 color = textColor,
                 maxLines = 1,

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeViewModel.kt
@@ -219,6 +219,7 @@ class HomeViewModel @Inject constructor(
     private var worldClockCities: List<WorldClockCity> = emptyList()
     private var countdownEvents: List<CountdownEvent> = emptyList()
     private var showWorldClockWeather: Boolean = false
+    private var showHomeAirQuality: Boolean = false
     private var worldClockWeatherTexts: Map<String, String> = emptyMap()
     private var worldClockWeatherFetchJob: Job? = null
 
@@ -1007,6 +1008,12 @@ class HomeViewModel @Inject constructor(
             }
             syncWeatherTicker()
         }
+        observeFlow(preferencesManager.showHomeAirQualityFlow.distinctUntilChanged()) { showAqi ->
+            showHomeAirQuality = showAqi
+            if (_uiState.value.showHomeWeather) {
+                refreshWeather()
+            }
+        }
     }
 
     private fun observeWorldClockWeatherPreference() {
@@ -1557,7 +1564,8 @@ class HomeViewModel @Inject constructor(
                                         weatherRepository.getWeather(
                                                 lat,
                                                 lon,
-                                                useFahrenheit = useFahrenheit
+                                                useFahrenheit = useFahrenheit,
+                                                includeAqi = showHomeAirQuality,
                                         )
                                     },
                             weatherUseFahrenheit = useFahrenheit,

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/SettingsScreen.kt
@@ -1008,6 +1008,16 @@ fun HomeWidgetsSettingsScreen(
             }
             item {
                 SettingsToggleRow(
+                        label = stringResource(R.string.settings_show_home_air_quality),
+                        subtitle =
+                                stringResource(R.string.settings_show_home_air_quality_subtitle),
+                        checked = uiState.showHomeAirQuality,
+                        enabled = uiState.showHomeWeather,
+                        onCheckedChange = viewModel::setShowHomeAirQuality,
+                )
+            }
+            item {
+                SettingsToggleRow(
                         label = stringResource(R.string.settings_show_world_clock_weather),
                         subtitle =
                                 stringResource(R.string.settings_show_world_clock_weather_subtitle),

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/SettingsViewModel.kt
@@ -100,6 +100,7 @@ data class SettingsUiState(
         val showHomeClock: Boolean = true,
         val showHomeDate: Boolean = true,
         val showHomeWeather: Boolean = true,
+        val showHomeAirQuality: Boolean = false,
         val showWorldClockWeather: Boolean = false,
         val showHomeBattery: Boolean = true,
         val showHomeMedia: Boolean = false,
@@ -302,14 +303,20 @@ constructor(
                             preferencesManager.preferredCalendarTapFlow,
                             preferencesManager.homeDateFormatStyleFlow,
                             preferencesManager.temperatureUnitFlow,
-                            preferencesManager.showWorldClockWeatherFlow,
-                    ) { clk, cal, fmt, tempUnit, showWorldClockWeather ->
+                            combine(
+                                    preferencesManager.showWorldClockWeatherFlow,
+                                    preferencesManager.showHomeAirQualityFlow,
+                            ) { showWorldClockWeather, showHomeAirQuality ->
+                                showWorldClockWeather to showHomeAirQuality
+                            },
+                    ) { clk, cal, fmt, tempUnit, weatherExtras ->
                         HomeWidgetTapsAndFormat(
                                 clk,
                                 cal,
                                 fmt,
                                 tempUnit,
-                                showWorldClockWeather,
+                                weatherExtras.first,
+                                weatherExtras.second,
                         )
                     }
             val homeWidgetItemsFlow =
@@ -340,6 +347,7 @@ constructor(
                                 homeDateFormatStyle = taps.homeDateFormatStyle,
                                 temperatureUnit = taps.temperatureUnit,
                                 showWorldClockWeather = taps.showWorldClockWeather,
+                                showHomeAirQuality = taps.showHomeAirQuality,
                         )
                     }
             val drawerPrefsFlow =
@@ -532,6 +540,7 @@ constructor(
                         showHomeClock = homeWidgetItems.showClock,
                         showHomeDate = homeWidgetItems.showDate,
                         showHomeWeather = homeWidgetItems.showWeather,
+                        showHomeAirQuality = homeWidgetItems.showHomeAirQuality,
                         showWorldClockWeather = homeWidgetItems.showWorldClockWeather,
                         showHomeBattery = homeWidgetItems.showBattery,
                         showHomeMedia = homeWidgetItems.showMedia,
@@ -589,6 +598,7 @@ constructor(
             val homeDateFormatStyle: HomeDateFormatStyle,
             val temperatureUnit: TemperatureUnit,
             val showWorldClockWeather: Boolean,
+            val showHomeAirQuality: Boolean,
     )
 
     private data class HomeWidgetItemSettings(
@@ -609,6 +619,7 @@ constructor(
             val homeDateFormatStyle: HomeDateFormatStyle,
             val temperatureUnit: TemperatureUnit,
             val showWorldClockWeather: Boolean,
+            val showHomeAirQuality: Boolean,
     )
 
     private data class FavoritesBase(
@@ -948,6 +959,8 @@ constructor(
     fun setShowHomeDate(show: Boolean) = launchPreferences { setShowHomeDate(show) }
 
     fun setShowHomeWeather(show: Boolean) = launchPreferences { setShowHomeWeather(show) }
+
+    fun setShowHomeAirQuality(show: Boolean) = launchPreferences { setShowHomeAirQuality(show) }
 
     fun setShowWorldClockWeather(show: Boolean) =
             launchPreferences { setShowWorldClockWeather(show) }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,6 +195,9 @@
     <string name="settings_temperature_unit_celsius">Celsius (°C)</string>
     <string name="settings_temperature_unit_fahrenheit">Fahrenheit (°F)</string>
     <string name="settings_show_home_weather">Show weather</string>
+    <string name="settings_show_home_air_quality">Show air quality index</string>
+    <string name="settings_show_home_air_quality_subtitle">Display AQI next to the weather temperature</string>
+    <string name="weather_with_aqi_format">%1$s · AQI %2$d</string>
     <string name="settings_show_world_clock_weather">Show weather on world clocks</string>
     <string name="settings_show_world_clock_weather_subtitle">Looks up conditions from each city label</string>
     <string name="settings_show_home_battery">Show battery level</string>

--- a/app/src/test/java/com/lu4p/fokuslauncher/data/repository/WeatherRepositoryTest.kt
+++ b/app/src/test/java/com/lu4p/fokuslauncher/data/repository/WeatherRepositoryTest.kt
@@ -3,8 +3,10 @@ package com.lu4p.fokuslauncher.data.repository
 import com.lu4p.fokuslauncher.R
 import com.lu4p.fokuslauncher.ui.components.weatherMaterialSymbolDrawableRes
 import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -21,6 +23,7 @@ class WeatherRepositoryTest {
     private lateinit var repository: WeatherRepository
     private lateinit var mockWebServer: MockWebServer
     private lateinit var originalBaseUrl: String
+    private lateinit var originalAirQualityUrl: String
 
     @Before
     fun setup() {
@@ -28,7 +31,10 @@ class WeatherRepositoryTest {
         mockWebServer.start()
 
         originalBaseUrl = WeatherRepository.OPEN_METEO_BASE_URL
-        WeatherRepository.OPEN_METEO_BASE_URL = mockWebServer.url("/").toString()
+        originalAirQualityUrl = WeatherRepository.OPEN_METEO_AIR_QUALITY_URL
+        WeatherRepository.OPEN_METEO_BASE_URL = mockWebServer.url("/forecast").toString()
+        WeatherRepository.OPEN_METEO_AIR_QUALITY_URL =
+                mockWebServer.url("/air-quality").toString()
 
         repository = WeatherRepository()
     }
@@ -36,6 +42,7 @@ class WeatherRepositoryTest {
     @After
     fun tearDown() {
         WeatherRepository.OPEN_METEO_BASE_URL = originalBaseUrl
+        WeatherRepository.OPEN_METEO_AIR_QUALITY_URL = originalAirQualityUrl
         mockWebServer.shutdown()
     }
 
@@ -237,6 +244,162 @@ class WeatherRepositoryTest {
         assertEquals(22, berlinWeather?.temperature)
         assertEquals(30, tokyoWeather?.temperature)
         assertEquals(2, mockWebServer.requestCount)
+    }
+
+    @Test
+    fun `getWeather includes european aqi when requested`() = runTest {
+        val forecast =
+                """
+            {
+              "current": {
+                "temperature_2m": 22.5,
+                "weather_code": 3
+              }
+            }
+        """
+                        .trimIndent()
+        val airQuality =
+                """
+            {
+              "current": {
+                "european_aqi": 29
+              }
+            }
+        """
+                        .trimIndent()
+        mockWebServer.dispatcher =
+                object : Dispatcher() {
+                    override fun dispatch(request: RecordedRequest): MockResponse {
+                        return when {
+                            request.path?.startsWith("/air-quality") == true ->
+                                    MockResponse().setResponseCode(200).setBody(airQuality)
+                            else -> MockResponse().setResponseCode(200).setBody(forecast)
+                        }
+                    }
+                }
+
+        val weather = repository.getWeather(52.52, 13.41, includeAqi = true)
+
+        assertNotNull(weather)
+        assertEquals(22, weather?.temperature)
+        assertEquals(29, weather?.aqi)
+        val aqiRequest =
+                (0 until mockWebServer.requestCount)
+                        .map { mockWebServer.takeRequest() }
+                        .first { it.path?.startsWith("/air-quality") == true }
+        assertTrue(aqiRequest.requestUrl!!.queryParameter("current") == "european_aqi")
+    }
+
+    @Test
+    fun `getWeather requests us aqi when fahrenheit and includeAqi`() = runTest {
+        val forecast =
+                """
+            {
+              "current": {
+                "temperature_2m": 72.0,
+                "weather_code": 0
+              }
+            }
+        """
+                        .trimIndent()
+        val airQuality =
+                """
+            {
+              "current": {
+                "us_aqi": 42
+              }
+            }
+        """
+                        .trimIndent()
+        mockWebServer.dispatcher =
+                object : Dispatcher() {
+                    override fun dispatch(request: RecordedRequest): MockResponse {
+                        return when {
+                            request.path?.startsWith("/air-quality") == true ->
+                                    MockResponse().setResponseCode(200).setBody(airQuality)
+                            else -> MockResponse().setResponseCode(200).setBody(forecast)
+                        }
+                    }
+                }
+
+        val weather =
+                repository.getWeather(52.52, 13.41, useFahrenheit = true, includeAqi = true)
+
+        assertEquals(42, weather?.aqi)
+        val aqiRequest =
+                (0 until mockWebServer.requestCount)
+                        .map { mockWebServer.takeRequest() }
+                        .first { it.path?.startsWith("/air-quality") == true }
+        assertTrue(aqiRequest.requestUrl!!.queryParameter("current") == "us_aqi")
+    }
+
+    @Test
+    fun `getWeather keeps temperature when air quality request fails`() = runTest {
+        val forecast =
+                """
+            {
+              "current": {
+                "temperature_2m": 18.0,
+                "weather_code": 0
+              }
+            }
+        """
+                        .trimIndent()
+        mockWebServer.dispatcher =
+                object : Dispatcher() {
+                    override fun dispatch(request: RecordedRequest): MockResponse {
+                        return when {
+                            request.path?.startsWith("/air-quality") == true ->
+                                    MockResponse().setResponseCode(500)
+                            else -> MockResponse().setResponseCode(200).setBody(forecast)
+                        }
+                    }
+                }
+
+        val weather = repository.getWeather(52.52, 13.41, includeAqi = true)
+
+        assertEquals(18, weather?.temperature)
+        assertNull(weather?.aqi)
+    }
+
+    @Test
+    fun `getWeather does not use aqi-less cache when includeAqi becomes true`() = runTest {
+        val forecast =
+                """
+            {
+              "current": {
+                "temperature_2m": 22.5,
+                "weather_code": 3
+              }
+            }
+        """
+                        .trimIndent()
+        val airQuality =
+                """
+            {
+              "current": {
+                "european_aqi": 55
+              }
+            }
+        """
+                        .trimIndent()
+        mockWebServer.dispatcher =
+                object : Dispatcher() {
+                    override fun dispatch(request: RecordedRequest): MockResponse {
+                        return when {
+                            request.path?.startsWith("/air-quality") == true ->
+                                    MockResponse().setResponseCode(200).setBody(airQuality)
+                            else -> MockResponse().setResponseCode(200).setBody(forecast)
+                        }
+                    }
+                }
+
+        val withoutAqi = repository.getWeather(52.52, 13.41, includeAqi = false)
+        val withAqi = repository.getWeather(52.52, 13.41, includeAqi = true)
+
+        assertNull(withoutAqi?.aqi)
+        assertEquals(55, withAqi?.aqi)
+        assertTrue(mockWebServer.requestCount >= 2)
     }
 
     @Test

--- a/app/src/test/java/com/lu4p/fokuslauncher/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/lu4p/fokuslauncher/ui/home/HomeViewModelTest.kt
@@ -131,6 +131,7 @@ class HomeViewModelTest {
         every { preferencesManager.showHomeClockFlow } returns flowOf(true)
         every { preferencesManager.showHomeDateFlow } returns flowOf(true)
         every { preferencesManager.showHomeWeatherFlow } returns flowOf(true)
+        every { preferencesManager.showHomeAirQualityFlow } returns flowOf(false)
         every { preferencesManager.showWorldClockWeatherFlow } returns flowOf(false)
         every { preferencesManager.showHomeBatteryFlow } returns flowOf(true)
         every { preferencesManager.showHomeMediaFlow } returns flowOf(false)


### PR DESCRIPTION
## Summary

- Add an opt-in home weather setting to display the air quality index.
- Fetch and cache European or US AQI based on the selected temperature unit.
- Display AQI beside the temperature and cover repository and UI behavior with tests.

## Testing

- Added `WeatherRepository` tests for AQI requests, failures, cache separation, and unit selection.
- Added a home screen UI test verifying AQI display.
- Not run