### PR TITLE
Organize settings into dedicated category screens

### DIFF
--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/navigation/NavGraph.kt
@@ -69,11 +69,14 @@ import com.lu4p.fokuslauncher.ui.drawer.AppDrawerViewModel
 import com.lu4p.fokuslauncher.ui.home.HomeScreen
 import com.lu4p.fokuslauncher.ui.home.HomeViewModel
 import com.lu4p.fokuslauncher.ui.onboarding.OnboardingScreen
+import com.lu4p.fokuslauncher.ui.settings.AppearanceSettingsScreen
+import com.lu4p.fokuslauncher.ui.settings.AppsManagementSettingsScreen
 import com.lu4p.fokuslauncher.ui.settings.CategoryAppsScreen
 import com.lu4p.fokuslauncher.ui.settings.CategorySettingsScreen
 import com.lu4p.fokuslauncher.ui.settings.EditHomeAppsScreen
 import com.lu4p.fokuslauncher.ui.settings.EditShortcutsScreen
 import com.lu4p.fokuslauncher.ui.settings.DeviceControlSettingsScreen
+import com.lu4p.fokuslauncher.ui.settings.DrawerBehaviorSettingsScreen
 import com.lu4p.fokuslauncher.ui.settings.DrawerDotSearchSettingsScreen
 import com.lu4p.fokuslauncher.ui.settings.HomeWidgetsSettingsScreen
 import com.lu4p.fokuslauncher.ui.settings.ProfileNamesSettingsScreen
@@ -97,6 +100,9 @@ object Routes {
     const val SETTINGS_HOME_WIDGETS = "settings_home_widgets"
     const val SETTINGS_DRAWER_DOT_SEARCH = "settings_drawer_dot_search"
     const val SETTINGS_PROFILE_NAMES = "settings_profile_names"
+    const val SETTINGS_APPEARANCE = "settings_appearance"
+    const val SETTINGS_DRAWER_BEHAVIOR = "settings_drawer_behavior"
+    const val SETTINGS_APPS_MANAGEMENT = "settings_apps_management"
 }
 
 private const val SWIPE_THRESHOLD = 100f
@@ -666,11 +672,6 @@ fun FokusNavGraph(
                 SettingsScreen(
                     viewModel = settingsVm,
                     onNavigateBack = { navController.popBackStack() },
-                    onNavigateToHome = {
-                        keyboardController?.hide()
-                        showDrawer = false
-                        navController.popBackStack(Routes.HOME, inclusive = false)
-                    },
                     onEditHomeScreen = {
                         navController.navigateSingleTop(Routes.SETTINGS_EDIT_HOME_APPS)
                     },
@@ -689,7 +690,45 @@ fun FokusNavGraph(
                     onOpenHomeWidgetsSettings = {
                         navController.navigateSingleTop(Routes.SETTINGS_HOME_WIDGETS)
                     },
+                    onOpenAppearanceSettings = {
+                        navController.navigateSingleTop(Routes.SETTINGS_APPEARANCE)
+                    },
+                    onOpenDrawerBehaviorSettings = {
+                        navController.navigateSingleTop(Routes.SETTINGS_DRAWER_BEHAVIOR)
+                    },
+                    onOpenAppsManagementSettings = {
+                        navController.navigateSingleTop(Routes.SETTINGS_APPS_MANAGEMENT)
+                    },
                     backgroundScrim = Color.Black
+                )
+            }
+
+            fokusSettingsComposable(Routes.SETTINGS_APPEARANCE) {
+                AppearanceSettingsScreen(
+                        viewModel = settingsViewModel(componentActivity),
+                        onNavigateBack = { navController.popBackStack() },
+                        onNavigateToHome = {
+                            keyboardController?.hide()
+                            showDrawer = false
+                            navController.popBackStack(Routes.HOME, inclusive = false)
+                        },
+                        backgroundScrim = Color.Black,
+                )
+            }
+
+            fokusSettingsComposable(Routes.SETTINGS_DRAWER_BEHAVIOR) {
+                DrawerBehaviorSettingsScreen(
+                        viewModel = settingsViewModel(componentActivity),
+                        onNavigateBack = { navController.popBackStack() },
+                        backgroundScrim = Color.Black,
+                )
+            }
+
+            fokusSettingsComposable(Routes.SETTINGS_APPS_MANAGEMENT) {
+                AppsManagementSettingsScreen(
+                        viewModel = settingsViewModel(componentActivity),
+                        onNavigateBack = { navController.popBackStack() },
+                        backgroundScrim = Color.Black,
                 )
             }
 

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/AppearanceSettingsScreen.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/AppearanceSettingsScreen.kt
@@ -1,0 +1,300 @@
+package com.lu4p.fokuslauncher.ui.settings
+
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.lu4p.fokuslauncher.R
+import com.lu4p.fokuslauncher.data.font.CustomFontImportFailure
+import com.lu4p.fokuslauncher.media.MediaNotificationHelper
+import com.lu4p.fokuslauncher.ui.settings.components.SectionHeader
+import com.lu4p.fokuslauncher.ui.settings.components.SettingsDivider
+import com.lu4p.fokuslauncher.ui.settings.components.SettingsRow
+import com.lu4p.fokuslauncher.ui.settings.components.SettingsToggleRow
+import com.lu4p.fokuslauncher.ui.theme.FokusBackdrop
+import com.lu4p.fokuslauncher.ui.util.OnResumeEffect
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AppearanceSettingsScreen(
+        viewModel: SettingsViewModel = hiltViewModel(),
+        onNavigateBack: () -> Unit = {},
+        onNavigateToHome: () -> Unit = {},
+        backgroundScrim: Color = FokusBackdrop.ScrimColorWithoutBlur,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val installedFontFamilies by viewModel.installedFontFamilies.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    var mediaNotificationAccessTick by remember { mutableIntStateOf(0) }
+    var pendingNotificationIndicatorsEnable by remember { mutableStateOf(false) }
+    OnResumeEffect(lifecycleOwner) { mediaNotificationAccessTick++ }
+    val mediaNotificationAccessEnabled =
+            remember(mediaNotificationAccessTick) {
+                MediaNotificationHelper.isListenerEnabled(context)
+            }
+    LaunchedEffect(
+            mediaNotificationAccessTick,
+            uiState.showNotificationIndicators,
+            pendingNotificationIndicatorsEnable,
+    ) {
+        if (pendingNotificationIndicatorsEnable && mediaNotificationAccessEnabled) {
+            pendingNotificationIndicatorsEnable = false
+            viewModel.setShowNotificationIndicators(true)
+        } else if (uiState.showNotificationIndicators && !mediaNotificationAccessEnabled) {
+            viewModel.setShowNotificationIndicators(false)
+        }
+    }
+
+    val wallpaperPickerLauncher =
+            rememberLauncherForActivityResult(contract = ActivityResultContracts.GetContent()) {
+                    uri ->
+                uri?.let {
+                    viewModel.setSystemWallpaper(it)
+                    onNavigateToHome()
+                }
+            }
+
+    val fontImportFailedUnreadable =
+            stringResource(R.string.settings_font_import_failed_unreadable)
+    val fontImportFailedExtension =
+            stringResource(R.string.settings_font_import_failed_extension)
+    val fontImportFailedInvalid = stringResource(R.string.settings_font_import_failed_invalid)
+    val fontImportFailedIo = stringResource(R.string.settings_font_import_failed_io)
+    val fontPickerLauncher =
+            rememberLauncherForActivityResult(contract = ActivityResultContracts.OpenDocument()) {
+                    uri ->
+                uri?.let { picked ->
+                    viewModel.importCustomFont(picked) { failure ->
+                        val message =
+                                when (failure) {
+                                    CustomFontImportFailure.UNREADABLE_URI ->
+                                            fontImportFailedUnreadable
+                                    CustomFontImportFailure.INVALID_EXTENSION ->
+                                            fontImportFailedExtension
+                                    CustomFontImportFailure.INVALID_FONT -> fontImportFailedInvalid
+                                    CustomFontImportFailure.IO_ERROR -> fontImportFailedIo
+                                    null -> null
+                                }
+                        if (message != null) {
+                            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                }
+            }
+
+    Column(
+            modifier =
+                    Modifier.fillMaxSize()
+                            .background(backgroundScrim)
+                            .navigationBarsPadding()
+                            .testTag("appearance_settings_screen")
+    ) {
+        FokusSettingsTopBar(
+                titleText = stringResource(R.string.settings_look_and_feel_title),
+                onNavigateBack = onNavigateBack,
+                containerColor = MaterialTheme.colorScheme.background,
+        )
+
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
+            items(
+                    listOf(
+                            Triple(
+                                    R.string.settings_show_status_bar,
+                                    uiState.showStatusBar,
+                                    viewModel::setShowStatusBar,
+                            ),
+                            Triple(
+                                    R.string.settings_allow_landscape_rotation,
+                                    uiState.allowLandscapeRotation,
+                                    viewModel::setAllowLandscapeRotation,
+                            ),
+                    ),
+                    key = { it.first },
+            ) { (labelRes, checked, onChange) ->
+                SettingsToggleRow(
+                        label = stringResource(labelRes),
+                        checked = checked,
+                        onCheckedChange = onChange,
+                )
+            }
+            item {
+                AppLanguageDropdown(
+                        currentTag = uiState.appLocaleTag,
+                        onTagSelected = viewModel::setAppLocaleTag,
+                )
+            }
+            item {
+                LauncherFontFamilyDropdown(
+                        currentFamilyName = uiState.launcherFontFamilyName,
+                        installedFamilies = installedFontFamilies,
+                        hasCustomFontFile = uiState.hasCustomFontFile,
+                        customFontDisplayName = uiState.customFontDisplayName,
+                        resolveCustomFontFile = viewModel::resolveCustomFontFile,
+                        onFamilySelected = viewModel::setLauncherFontFamilyName,
+                )
+            }
+            item {
+                SettingsRow(
+                        label = stringResource(R.string.settings_font_import_ttf),
+                        subtitle = stringResource(R.string.settings_font_import_ttf_subtitle),
+                        verticalPadding = 14.dp,
+                        onClick = {
+                            fontPickerLauncher.launch(
+                                    arrayOf(
+                                            "font/ttf",
+                                            "application/x-font-ttf",
+                                            "application/font-sfnt",
+                                            "application/octet-stream",
+                                    )
+                            )
+                        },
+                )
+            }
+            if (uiState.hasCustomFontFile) {
+                item {
+                    SettingsRow(
+                            label = stringResource(R.string.settings_font_clear_custom),
+                            verticalPadding = 14.dp,
+                            onClick = { viewModel.clearCustomFont() },
+                    )
+                }
+            }
+            item {
+                LauncherFontSizeSlider(
+                        currentScale = uiState.launcherFontScale,
+                        onScaleChange = viewModel::setLauncherFontScale,
+                )
+            }
+            item {
+                LauncherVisualStyleDropdown(
+                        currentStyle = uiState.launcherVisualStyle,
+                        onStyleSelected = viewModel::setLauncherVisualStyle,
+                        homeUsesPhotoWallpaper = uiState.homeUsesPhotoWallpaper,
+                )
+            }
+            item {
+                SettingsToggleRow(
+                        label = stringResource(R.string.settings_glow_label),
+                        checked =
+                                uiState.launcherGlowEnabled && !uiState.homeUsesPhotoWallpaper,
+                        onCheckedChange = viewModel::setLauncherGlowEnabled,
+                        subtitle =
+                                stringResource(
+                                        if (uiState.homeUsesPhotoWallpaper) {
+                                            R.string.settings_look_locked_image_wallpaper
+                                        } else {
+                                            R.string.settings_glow_subtitle
+                                        }
+                                ),
+                        enabled = !uiState.homeUsesPhotoWallpaper,
+                )
+            }
+            item {
+                SettingsRow(
+                        label = stringResource(R.string.settings_set_background_image),
+                        verticalPadding = 14.dp,
+                        onClick = { wallpaperPickerLauncher.launch("image/*") },
+                )
+            }
+            item {
+                SettingsRow(
+                        label = stringResource(R.string.settings_set_black_wallpaper),
+                        verticalPadding = 14.dp,
+                        onClick = {
+                            viewModel.setBlackWallpaper()
+                            onNavigateToHome()
+                        },
+                )
+            }
+            if (uiState.homeUsesPhotoWallpaper) {
+                item {
+                    SectionHeader(
+                            stringResource(R.string.settings_section_image_wallpaper_accessibility)
+                    )
+                }
+                item {
+                    PhotoWallpaperOutlineWidthSlider(
+                            currentWidthDp = uiState.photoWallpaperOutlineWidthDp,
+                            onWidthDpChange = viewModel::setPhotoWallpaperOutlineWidthDp,
+                    )
+                }
+                item {
+                    PhotoWallpaperDrawerOverlaySlider(
+                            currentIntensity = uiState.photoWallpaperDrawerOverlayIntensity,
+                            onIntensityChange = viewModel::setPhotoWallpaperDrawerOverlayIntensity,
+                    )
+                }
+            }
+            item { SettingsDivider() }
+            item {
+                SettingsToggleRow(
+                        label = stringResource(R.string.settings_notification_indicators),
+                        subtitle =
+                                if (mediaNotificationAccessEnabled) {
+                                    stringResource(R.string.settings_notification_indicators_subtitle)
+                                } else {
+                                    stringResource(
+                                            R.string
+                                                    .settings_notification_indicators_subtitle_grant_access
+                                    )
+                                },
+                        checked = uiState.showNotificationIndicators,
+                        onCheckedChange = { checked ->
+                            if (checked) {
+                                if (mediaNotificationAccessEnabled) {
+                                    viewModel.setShowNotificationIndicators(true)
+                                } else {
+                                    pendingNotificationIndicatorsEnable = true
+                                    MediaNotificationHelper.openListenerSettings(context)
+                                }
+                            } else {
+                                pendingNotificationIndicatorsEnable = false
+                                viewModel.setShowNotificationIndicators(false)
+                            }
+                        },
+                )
+            }
+            if (uiState.showNotificationIndicators) {
+                item {
+                    NotificationIndicatorStyleDropdown(
+                            currentStyle = uiState.notificationIndicatorStyle,
+                            onStyleSelected = viewModel::setNotificationIndicatorStyle,
+                    )
+                }
+                item {
+                    NotificationIndicatorColorDropdown(
+                            currentColor = uiState.notificationIndicatorColor,
+                            onColorSelected = viewModel::setNotificationIndicatorColorPreset,
+                    )
+                }
+            }
+            item { Spacer(Modifier.height(32.dp)) }
+        }
+    }
+}

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/AppsManagementSettingsScreen.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/AppsManagementSettingsScreen.kt
@@ -1,0 +1,130 @@
+package com.lu4p.fokuslauncher.ui.settings
+
+import android.os.Build
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Restore
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.lu4p.fokuslauncher.R
+import com.lu4p.fokuslauncher.ui.components.LauncherIcon
+import com.lu4p.fokuslauncher.ui.settings.components.SettingsDivider
+import com.lu4p.fokuslauncher.ui.theme.FokusBackdrop
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AppsManagementSettingsScreen(
+        viewModel: SettingsViewModel = hiltViewModel(),
+        onNavigateBack: () -> Unit = {},
+        backgroundScrim: Color = FokusBackdrop.ScrimColorWithoutBlur,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Column(
+            modifier =
+                    Modifier.fillMaxSize()
+                            .background(backgroundScrim)
+                            .navigationBarsPadding()
+                            .testTag("apps_management_settings_screen")
+    ) {
+        FokusSettingsTopBar(
+                titleText = stringResource(R.string.settings_apps_management_title),
+                onNavigateBack = onNavigateBack,
+                containerColor = MaterialTheme.colorScheme.background,
+        )
+
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
+            // System app archiving APIs (ApplicationInfo.isArchived, etc.) require API 35+.
+            if (Build.VERSION.SDK_INT >= 35) {
+                manageableAppsSection(
+                        headerRes = R.string.settings_section_archived_apps,
+                        emptyTextRes = R.string.settings_no_archived_apps,
+                        apps = uiState.archivedApps,
+                        key = { "archived_${it.stableKey}" },
+                        label = { it.app.label },
+                        subtitle = { archived ->
+                            archived.profileLabel?.let { pl -> "$pl • ${archived.app.packageName}" }
+                                    ?: archived.app.packageName
+                        },
+                        onRowClick = viewModel::restoreArchivedApp,
+                        trailingContent = {
+                            Spacer(Modifier.width(8.dp))
+                            LauncherIcon(
+                                    Icons.Default.Restore,
+                                    stringResource(R.string.cd_restore_archived_app),
+                                    tint = MaterialTheme.colorScheme.secondary,
+                                    iconSize = 24.dp,
+                            )
+                        },
+                )
+                item { SettingsDivider() }
+            }
+
+            manageableAppsSection(
+                    headerRes = R.string.settings_section_hidden_apps,
+                    emptyTextRes = R.string.settings_no_hidden_apps,
+                    apps = uiState.hiddenApps,
+                    key = { "hidden_${it.stableKey}" },
+                    label = { it.label },
+                    subtitle = { app ->
+                        app.profileLabel?.let { pl -> "$pl • ${app.packageName}" } ?: app.packageName
+                    },
+                    onRowClick = {
+                        viewModel.unhideApp(it.packageName, it.profileKey, it.launcherShortcutId)
+                    },
+                    trailingContent = {
+                        Spacer(Modifier.width(8.dp))
+                        LauncherIcon(
+                                Icons.Default.Visibility,
+                                stringResource(R.string.cd_unhide_app),
+                                tint = MaterialTheme.colorScheme.secondary,
+                                iconSize = 24.dp,
+                        )
+                    },
+            )
+            item { SettingsDivider() }
+
+            manageableAppsSection(
+                    headerRes = R.string.settings_section_renamed_apps,
+                    emptyTextRes = R.string.settings_no_renamed_apps,
+                    apps = uiState.renamedApps,
+                    key = { "renamed_${it.stableKey}" },
+                    label = { it.customName },
+                    subtitle = { app ->
+                        app.profileLabel?.let { pl -> "$pl • ${app.packageName}" } ?: app.packageName
+                    },
+                    onRowClick = {
+                        viewModel.removeRename(it.packageName, it.profileKey, it.launcherShortcutId)
+                    },
+                    trailingContent = {
+                        Spacer(Modifier.width(8.dp))
+                        LauncherIcon(
+                                Icons.Default.Close,
+                                stringResource(R.string.cd_remove_rename),
+                                tint = MaterialTheme.colorScheme.secondary,
+                                iconSize = 24.dp,
+                        )
+                    },
+            )
+            item { Spacer(Modifier.height(32.dp)) }
+        }
+    }
+}

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/DeviceControlSettingsScreen.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/DeviceControlSettingsScreen.kt
@@ -1,0 +1,149 @@
+package com.lu4p.fokuslauncher.ui.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.lu4p.fokuslauncher.R
+import com.lu4p.fokuslauncher.ui.components.AccessibilityProminentDisclosureOverlay
+import com.lu4p.fokuslauncher.ui.settings.components.SettingsToggleRow
+import com.lu4p.fokuslauncher.ui.theme.FokusBackdrop
+import com.lu4p.fokuslauncher.ui.util.OnResumeEffect
+import com.lu4p.fokuslauncher.utils.LockScreenHelper
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DeviceControlSettingsScreen(
+        viewModel: SettingsViewModel = hiltViewModel(),
+        onNavigateBack: () -> Unit = {},
+        backgroundScrim: Color = FokusBackdrop.ScrimColorWithoutBlur
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val accessibilityDisclosureAccepted by viewModel.accessibilityProminentDisclosureAccepted.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    var showAccessibilityProminentDisclosure by remember { mutableStateOf(false) }
+    var accessibilityResumeTick by remember { mutableIntStateOf(0) }
+    val lifecycleOwner = LocalLifecycleOwner.current
+    OnResumeEffect(lifecycleOwner) { accessibilityResumeTick++ }
+
+    val lockAccessibilityOn =
+            remember(accessibilityResumeTick) {
+                LockScreenHelper.isLockAccessibilityServiceEnabled(context)
+            }
+
+    LaunchedEffect(lockAccessibilityOn, uiState.longLockReturnHome) {
+        if (uiState.longLockReturnHome && !lockAccessibilityOn) {
+            viewModel.setLongLockReturnHome(false)
+        }
+    }
+
+    val deviceControlToggleRows =
+            listOf(
+                    DeviceControlToggleRow(
+                            R.string.settings_double_tap_to_lock,
+                            stringResource(R.string.settings_double_tap_to_lock_subtitle),
+                            uiState.doubleTapEmptyLock,
+                            viewModel::setDoubleTapEmptyLock,
+                    ),
+                    DeviceControlToggleRow(
+                            R.string.settings_return_home_after_long_lock,
+                            stringResource(R.string.settings_return_home_after_long_lock_subtitle),
+                            uiState.longLockReturnHome,
+                            viewModel::setLongLockReturnHome,
+                    ),
+            )
+
+    Box(
+            modifier = Modifier
+                    .fillMaxSize()
+                    .background(backgroundScrim)
+                    .navigationBarsPadding()
+                    .testTag("device_control_settings_screen")
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            FokusSettingsTopBar(
+                    titleText = stringResource(R.string.settings_accessibility_page_title),
+                    onNavigateBack = onNavigateBack,
+                    containerColor = MaterialTheme.colorScheme.background,
+            )
+
+            LazyColumn(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                item {
+                    SettingsToggleRow(
+                            label = stringResource(R.string.settings_accessibility_permission),
+                            subtitle =
+                                    stringResource(
+                                            if (lockAccessibilityOn) {
+                                                R.string.settings_accessibility_permission_enabled
+                                            } else {
+                                                R.string.settings_accessibility_permission_disabled
+                                            }
+                                    ),
+                            checked = lockAccessibilityOn,
+                            onCheckedChange = {
+                                when {
+                                    !lockAccessibilityOn && !accessibilityDisclosureAccepted ->
+                                            showAccessibilityProminentDisclosure = true
+                                    else ->
+                                            LockScreenHelper.openAccessibilitySettings(context)
+                                }
+                            }
+                    )
+                }
+
+                items(
+                        deviceControlToggleRows,
+                        key = { it.labelRes },
+                ) { row ->
+                    SettingsToggleRow(
+                            label = stringResource(row.labelRes),
+                            subtitle = row.subtitle,
+                            checked = row.checked,
+                            onCheckedChange = row.onCheckedChange,
+                            enabled = lockAccessibilityOn,
+                    )
+                }
+
+                if (lockAccessibilityOn && uiState.longLockReturnHome) {
+                    item {
+                        LongLockThresholdRow(
+                                currentMinutes = uiState.longLockReturnHomeThresholdMinutes,
+                                onMinutesSelected = viewModel::setLongLockReturnHomeThresholdMinutes
+                        )
+                    }
+                }
+            }
+        }
+
+        if (showAccessibilityProminentDisclosure) {
+            AccessibilityProminentDisclosureOverlay(
+                    onAccept = {
+                        showAccessibilityProminentDisclosure = false
+                        viewModel.acceptAccessibilityProminentDisclosureAndOpenSettings()
+                    },
+                    onNotNow = { showAccessibilityProminentDisclosure = false },
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/DrawerBehaviorSettingsScreen.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/DrawerBehaviorSettingsScreen.kt
@@ -1,0 +1,103 @@
+package com.lu4p.fokuslauncher.ui.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.lu4p.fokuslauncher.R
+import com.lu4p.fokuslauncher.ui.settings.components.SettingsToggleRow
+import com.lu4p.fokuslauncher.ui.theme.FokusBackdrop
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DrawerBehaviorSettingsScreen(
+        viewModel: SettingsViewModel = hiltViewModel(),
+        onNavigateBack: () -> Unit = {},
+        backgroundScrim: Color = FokusBackdrop.ScrimColorWithoutBlur,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Column(
+            modifier =
+                    Modifier.fillMaxSize()
+                            .background(backgroundScrim)
+                            .navigationBarsPadding()
+                            .testTag("drawer_behavior_settings_screen")
+    ) {
+        FokusSettingsTopBar(
+                titleText = stringResource(R.string.settings_drawer_behavior_title),
+                onNavigateBack = onNavigateBack,
+                containerColor = MaterialTheme.colorScheme.background,
+        )
+
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
+            item {
+                SettingsToggleRow(
+                        label = stringResource(R.string.settings_drawer_search_auto_launch),
+                        subtitle =
+                                stringResource(R.string.settings_drawer_search_auto_launch_subtitle),
+                        checked = uiState.drawerSearchAutoLaunch,
+                        onCheckedChange = viewModel::setDrawerSearchAutoLaunch,
+                )
+            }
+            if (!uiState.drawerSidebarCategories) {
+                item {
+                    SettingsToggleRow(
+                            label =
+                                    stringResource(
+                                            R.string.settings_drawer_scroll_to_top_auto_keyboard
+                                    ),
+                            subtitle =
+                                    stringResource(
+                                            R.string
+                                                    .settings_drawer_scroll_to_top_auto_keyboard_subtitle
+                                    ),
+                            checked = uiState.drawerScrollToTopAutoKeyboard,
+                            onCheckedChange = viewModel::setDrawerScrollToTopAutoKeyboard,
+                    )
+                }
+            }
+            item {
+                SettingsToggleRow(
+                        label = stringResource(R.string.settings_drawer_sidebar_categories),
+                        subtitle =
+                                stringResource(
+                                        R.string.settings_drawer_sidebar_categories_subtitle
+                                ),
+                        checked = uiState.drawerSidebarCategories,
+                        onCheckedChange = viewModel::setDrawerSidebarCategories,
+                )
+            }
+            if (uiState.drawerSidebarCategories) {
+                item {
+                    DrawerCategoryRailSideRow(
+                            railOnLeft = uiState.drawerCategorySidebarOnLeft,
+                            onRailOnLeftChanged = viewModel::setDrawerCategorySidebarOnLeft,
+                    )
+                }
+            }
+            item {
+                DrawerAppSortRow(
+                        currentMode = uiState.drawerAppSortMode,
+                        showCustomSortOption = uiState.drawerSidebarCategories,
+                        onModeChanged = viewModel::setDrawerAppSortMode,
+                )
+            }
+            item { Spacer(Modifier.height(32.dp)) }
+        }
+    }
+}

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/HomeWidgetsSettingsScreen.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/HomeWidgetsSettingsScreen.kt
@@ -1,0 +1,516 @@
+package com.lu4p.fokuslauncher.ui.settings
+
+import androidx.activity.compose.LocalActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.lu4p.fokuslauncher.R
+import com.lu4p.fokuslauncher.data.model.HomeExtraWidgetAddType
+import com.lu4p.fokuslauncher.data.model.HomeExtraWidgetEntry
+import com.lu4p.fokuslauncher.data.model.displayNameForTimeZoneId
+import com.lu4p.fokuslauncher.data.model.formatUtcOffsetLabel
+import com.lu4p.fokuslauncher.media.MediaNotificationHelper
+import com.lu4p.fokuslauncher.ui.components.FokusTextButton
+import com.lu4p.fokuslauncher.ui.components.FokusAlertDialog
+import com.lu4p.fokuslauncher.ui.home.formatCountdownDateTimeLabel
+import com.lu4p.fokuslauncher.ui.settings.components.EditorDragHandleReorderIcon
+import com.lu4p.fokuslauncher.ui.settings.components.SettingsDivider
+import com.lu4p.fokuslauncher.ui.settings.components.SettingsRow
+import com.lu4p.fokuslauncher.ui.settings.components.SettingsToggleRow
+import com.lu4p.fokuslauncher.ui.theme.FokusBackdrop
+import com.lu4p.fokuslauncher.ui.util.OnResumeEffect
+import com.lu4p.fokuslauncher.ui.util.clickableWithSystemSound
+import com.lu4p.fokuslauncher.ui.util.rememberLocallyReorderedList
+import com.lu4p.fokuslauncher.ui.util.rememberVerticalSlotReorderState
+import com.lu4p.fokuslauncher.usage.UsageStatsHelper
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HomeWidgetsSettingsScreen(
+        viewModel: SettingsViewModel = hiltViewModel(),
+        onNavigateBack: () -> Unit = {},
+        backgroundScrim: Color = FokusBackdrop.ScrimColorWithoutBlur
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val resources = LocalResources.current
+    val activity = LocalActivity.current
+    val showAppPickerFor = remember { mutableStateOf<String?>(null) }
+
+    val (hasCoarseLocationPermission, requestCoarseLocation) =
+            rememberCoarseLocationPermission(context, activity)
+
+    var mediaNotificationAccessTick by remember { mutableIntStateOf(0) }
+    var pendingMediaEnable by remember { mutableStateOf(false) }
+    var usageAccessTick by remember { mutableIntStateOf(0) }
+    var pendingScreenTimeEnable by remember { mutableStateOf(false) }
+    var showAddOtherWidget by remember { mutableStateOf(false) }
+    var editingCityId by remember { mutableStateOf<String?>(null) }
+    var pendingEditNewestCity by remember { mutableStateOf(false) }
+    var editingCountdownId by remember { mutableStateOf<String?>(null) }
+    var pendingEditNewestCountdown by remember { mutableStateOf(false) }
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val extraWidgetsSource = uiState.homeExtraWidgets
+    val citiesById = remember(uiState.worldClockCities) { uiState.worldClockCities.associateBy { it.id } }
+    val eventsById = remember(uiState.countdownEvents) { uiState.countdownEvents.associateBy { it.id } }
+    val localExtras = rememberLocallyReorderedList(extraWidgetsSource)
+    val extraWidgets = localExtras.items
+    val reorderState = rememberVerticalSlotReorderState()
+    val onExtraCommit by rememberUpdatedState(viewModel::setHomeExtraWidgets)
+    OnResumeEffect(lifecycleOwner) {
+        mediaNotificationAccessTick++
+        usageAccessTick++
+    }
+    val mediaNotificationAccessEnabled =
+            remember(mediaNotificationAccessTick) {
+                MediaNotificationHelper.isListenerEnabled(context)
+            }
+    val usageAccessEnabled =
+            remember(usageAccessTick) { UsageStatsHelper.hasUsageAccess(context) }
+    LaunchedEffect(mediaNotificationAccessTick, uiState.showHomeMedia, pendingMediaEnable) {
+        if (pendingMediaEnable && mediaNotificationAccessEnabled) {
+            pendingMediaEnable = false
+            viewModel.setShowHomeMedia(true)
+        } else if (uiState.showHomeMedia && !mediaNotificationAccessEnabled) {
+            viewModel.setShowHomeMedia(false)
+        }
+    }
+    LaunchedEffect(usageAccessTick, uiState.showHomeScreenTime, pendingScreenTimeEnable) {
+        if (pendingScreenTimeEnable && usageAccessEnabled) {
+            pendingScreenTimeEnable = false
+            viewModel.setShowHomeScreenTime(true)
+        } else if (uiState.showHomeScreenTime && !usageAccessEnabled) {
+            viewModel.setShowHomeScreenTime(false)
+        }
+    }
+
+    Column(
+            modifier =
+                    Modifier.fillMaxSize()
+                            .background(backgroundScrim)
+                            .navigationBarsPadding()
+                            .testTag("home_widgets_settings_screen")
+    ) {
+        FokusSettingsTopBar(
+                titleText = stringResource(R.string.settings_home_widgets),
+                onNavigateBack = onNavigateBack,
+                containerColor = MaterialTheme.colorScheme.background,
+        )
+
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
+            items(
+                    listOf(
+                            Triple(R.string.settings_show_home_clock, uiState.showHomeClock, viewModel::setShowHomeClock),
+                            Triple(R.string.settings_show_home_date, uiState.showHomeDate, viewModel::setShowHomeDate),
+                    ),
+                    key = { it.first },
+            ) { (labelRes, checked, onChange) ->
+                SettingsToggleRow(
+                        label = stringResource(labelRes),
+                        checked = checked,
+                        onCheckedChange = onChange,
+                )
+            }
+            item {
+                HomeDateFormatDropdown(
+                        currentStyle = uiState.homeDateFormatStyle,
+                        enabled = uiState.showHomeDate,
+                        onStyleSelected = viewModel::setHomeDateFormatStyle,
+                )
+            }
+            items(
+                    listOf(
+                            Triple(R.string.settings_show_home_weather, uiState.showHomeWeather, viewModel::setShowHomeWeather),
+                    ),
+                    key = { it.first },
+            ) { (labelRes, checked, onChange) ->
+                SettingsToggleRow(
+                        label = stringResource(labelRes),
+                        checked = checked,
+                        onCheckedChange = onChange,
+                )
+            }
+            item {
+                SettingsToggleRow(
+                        label = stringResource(R.string.settings_show_home_air_quality),
+                        subtitle =
+                                stringResource(R.string.settings_show_home_air_quality_subtitle),
+                        checked = uiState.showHomeAirQuality,
+                        enabled = uiState.showHomeWeather,
+                        onCheckedChange = viewModel::setShowHomeAirQuality,
+                )
+            }
+            item {
+                SettingsToggleRow(
+                        label = stringResource(R.string.settings_show_world_clock_weather),
+                        subtitle =
+                                stringResource(R.string.settings_show_world_clock_weather_subtitle),
+                        checked = uiState.showWorldClockWeather,
+                        onCheckedChange = viewModel::setShowWorldClockWeather,
+                )
+            }
+            item {
+                TemperatureUnitDropdown(
+                        currentUnit = uiState.temperatureUnit,
+                        enabled = uiState.showHomeWeather || uiState.showWorldClockWeather,
+                        onUnitSelected = viewModel::setTemperatureUnit,
+                )
+            }
+            item {
+                SettingsToggleRow(
+                        label = stringResource(R.string.settings_show_home_screen_time),
+                        subtitle =
+                                if (usageAccessEnabled) {
+                                    stringResource(R.string.settings_show_home_screen_time_subtitle)
+                                } else {
+                                    stringResource(
+                                            R.string.settings_show_home_screen_time_subtitle_grant_access
+                                    )
+                                },
+                        checked = uiState.showHomeScreenTime,
+                        onCheckedChange = { checked ->
+                            if (checked) {
+                                if (usageAccessEnabled) {
+                                    viewModel.setShowHomeScreenTime(true)
+                                } else {
+                                    pendingScreenTimeEnable = true
+                                    UsageStatsHelper.openUsageAccessSettings(context)
+                                }
+                            } else {
+                                pendingScreenTimeEnable = false
+                                viewModel.setShowHomeScreenTime(false)
+                            }
+                        },
+                )
+            }
+            items(
+                    listOf(
+                            Triple(R.string.settings_show_home_battery, uiState.showHomeBattery, viewModel::setShowHomeBattery),
+                    ),
+                    key = { it.first },
+            ) { (labelRes, checked, onChange) ->
+                SettingsToggleRow(
+                        label = stringResource(labelRes),
+                        checked = checked,
+                        onCheckedChange = onChange,
+                )
+            }
+            item {
+                SettingsToggleRow(
+                        label = stringResource(R.string.settings_show_home_media),
+                        subtitle =
+                                if (mediaNotificationAccessEnabled) {
+                                    stringResource(R.string.settings_show_home_media_subtitle)
+                                } else {
+                                    stringResource(R.string.settings_show_home_media_subtitle_grant_access)
+                                },
+                        checked = uiState.showHomeMedia,
+                        onCheckedChange = { checked ->
+                            if (checked) {
+                                if (mediaNotificationAccessEnabled) {
+                                    viewModel.setShowHomeMedia(true)
+                                } else {
+                                    pendingMediaEnable = true
+                                    MediaNotificationHelper.openListenerSettings(context)
+                                }
+                            } else {
+                                pendingMediaEnable = false
+                                viewModel.setShowHomeMedia(false)
+                            }
+                        },
+                )
+            }
+            item { SettingsDivider() }
+            item {
+                SettingsRow(
+                        label = stringResource(R.string.settings_home_extra_widgets),
+                        subtitle =
+                                if (extraWidgets.isEmpty()) {
+                                    stringResource(R.string.settings_home_extra_widgets_empty)
+                                } else {
+                                    null
+                                },
+                )
+            }
+            items(
+                    count = extraWidgets.size,
+                    key = { extraWidgets[it].stableKey },
+            ) { index ->
+                val entry = extraWidgets[index]
+                val title: String
+                val subtitle: String
+                when (entry) {
+                    is HomeExtraWidgetEntry.WorldClock -> {
+                        val city = citiesById[entry.cityId]
+                        title = city?.label ?: stringResource(R.string.settings_world_clock_cities)
+                        subtitle =
+                                if (city == null) {
+                                    stringResource(R.string.settings_world_clock_cities_empty)
+                                } else {
+                                    val zone = displayNameForTimeZoneId(city.timeZoneId)
+                                    val offset = formatUtcOffsetLabel(city.timeZoneId)
+                                    "$zone · $offset"
+                                }
+                    }
+                    is HomeExtraWidgetEntry.Countdown -> {
+                        val event = eventsById[entry.eventId]
+                        title = event?.title ?: stringResource(R.string.settings_countdown_event)
+                        subtitle =
+                                if (event == null) {
+                                    stringResource(R.string.settings_countdown_event_empty)
+                                } else {
+                                    formatCountdownDateTimeLabel(context, event)
+                                }
+                    }
+                }
+                Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier =
+                                Modifier.fillMaxWidth()
+                                        .heightIn(min = 56.dp)
+                                        .graphicsLayer {
+                                            translationY = reorderState.translationYForIndex(index)
+                                        }
+                                        .clickableWithSystemSound {
+                                            when (entry) {
+                                                is HomeExtraWidgetEntry.WorldClock ->
+                                                        editingCityId = entry.cityId
+                                                is HomeExtraWidgetEntry.Countdown ->
+                                                        editingCountdownId = entry.eventId
+                                            }
+                                        }
+                                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                ) {
+                    EditorDragHandleReorderIcon(
+                            reorderState = reorderState,
+                            index = index,
+                            lastIndex = extraWidgets.lastIndex,
+                            onReorder = localExtras::reorder,
+                            onReset = {
+                                reorderState.reset {
+                                    localExtras.onDragEnd(onExtraCommit)
+                                }
+                            },
+                            entry.stableKey,
+                            extraWidgets.size,
+                            onDragGestureStart = localExtras::onDragStart,
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                                text = title,
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onBackground,
+                        )
+                        Text(
+                                text = subtitle,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.secondary,
+                        )
+                    }
+                    FokusTextButton(onClick = { viewModel.removeHomeExtraWidget(entry) }) {
+                        Text(stringResource(R.string.settings_remove_other_widget))
+                    }
+                }
+            }
+            item {
+                SettingsRow(
+                        label = stringResource(R.string.settings_add_other_widget),
+                        onClick = { showAddOtherWidget = true },
+                )
+            }
+            item { SettingsDivider() }
+            item {
+                WeatherAppSettingRow(
+                        hasCoarseLocationPermission = hasCoarseLocationPermission,
+                        onRequestLocationPermission = requestCoarseLocation,
+                        context = context,
+                        resources = resources,
+                        preferredWeatherTap = uiState.preferredWeatherTap,
+                        allApps = uiState.allApps,
+                        allShortcutActions = uiState.allShortcutActions,
+                        onPickApp = { showAppPickerFor.value = "weather" },
+                        onClear = { viewModel.setPreferredWeatherTap(null) },
+                )
+            }
+            items(
+                    listOf(
+                            WidgetTapPickerRow(
+                                    labelRes = R.string.settings_widget_clock_app,
+                                    tapTarget = uiState.preferredClockTap,
+                                    pickerKey = "clock",
+                                    onClear = { viewModel.setPreferredClockTap(null) },
+                            ),
+                            WidgetTapPickerRow(
+                                    labelRes = R.string.settings_widget_calendar_app,
+                                    tapTarget = uiState.preferredCalendarTap,
+                                    pickerKey = "calendar",
+                                    onClear = { viewModel.setPreferredCalendarTap(null) },
+                            ),
+                    ),
+                    key = { it.labelRes },
+            ) { row ->
+                ShortcutTargetRow(
+                        label = stringResource(row.labelRes),
+                        currentTarget =
+                                formatWidgetTapTarget(
+                                        context = context,
+                                        resources = resources,
+                                        binding = row.tapTarget,
+                                        allApps = uiState.allApps,
+                                        allActions = uiState.allShortcutActions,
+                                        emptyLabel = row.emptyLabel,
+                                ),
+                        onPickApp = { showAppPickerFor.value = row.pickerKey },
+                        onClear = row.onClear,
+                )
+            }
+        }
+    }
+
+    showAppPickerFor.value?.let { pickerTarget ->
+        ShortcutActionPickerDialog(
+                allActions = uiState.allShortcutActions,
+                allApps = uiState.allApps,
+                title = stringResource(R.string.edit_shortcuts_section_all_actions),
+                onSelect = { action ->
+                    when (pickerTarget) {
+                        "weather" -> viewModel.setPreferredWeatherTap(action)
+                        "clock" -> viewModel.setPreferredClockTap(action)
+                        "calendar" -> viewModel.setPreferredCalendarTap(action)
+                    }
+                    showAppPickerFor.value = null
+                },
+                onDismiss = { showAppPickerFor.value = null },
+                profileDisplayNameOverrides = uiState.profileDisplayNameOverrides,
+        )
+    }
+
+    if (showAddOtherWidget) {
+        FokusAlertDialog(
+                onDismissRequest = { showAddOtherWidget = false },
+                title = { Text(stringResource(R.string.settings_add_other_widget_title)) },
+                text = {
+                    Column {
+                        HomeExtraWidgetAddType.entries.forEach { type ->
+                            SettingsRow(
+                                    label = stringResource(type.labelRes),
+                                    subtitle =
+                                            stringResource(
+                                                    when (type) {
+                                                        HomeExtraWidgetAddType.WORLD_CLOCK ->
+                                                                R.string.settings_show_home_world_clock_subtitle
+                                                        HomeExtraWidgetAddType.COUNTDOWN ->
+                                                                R.string.settings_show_home_countdown_subtitle
+                                                    }
+                                            ),
+                                    horizontalPadding = 0.dp,
+                                    onClick = {
+                                        viewModel.addHomeExtraWidget(type)
+                                        showAddOtherWidget = false
+                                        when (type) {
+                                            HomeExtraWidgetAddType.WORLD_CLOCK ->
+                                                    pendingEditNewestCity = true
+                                            HomeExtraWidgetAddType.COUNTDOWN ->
+                                                    pendingEditNewestCountdown = true
+                                        }
+                                    },
+                            )
+                        }
+                    }
+                },
+                confirmButton = {},
+                dismissButton = {
+                    FokusTextButton(onClick = { showAddOtherWidget = false }) {
+                        Text(stringResource(R.string.action_cancel))
+                    }
+                },
+        )
+    }
+
+    // After adding a world clock, open the newest city for editing.
+    LaunchedEffect(uiState.worldClockCities, pendingEditNewestCity) {
+        if (pendingEditNewestCity) {
+            val newest = uiState.worldClockCities.maxByOrNull { it.position }
+            if (newest != null) {
+                editingCityId = newest.id
+                pendingEditNewestCity = false
+            }
+        }
+    }
+
+    LaunchedEffect(uiState.countdownEvents, pendingEditNewestCountdown) {
+        if (pendingEditNewestCountdown) {
+            val newest = uiState.countdownEvents.lastOrNull()
+            if (newest != null) {
+                editingCountdownId = newest.id
+                pendingEditNewestCountdown = false
+            }
+        }
+    }
+
+    editingCityId?.let { cityId ->
+        val city = citiesById[cityId]
+        if (city != null) {
+            WorldClockCityEditDialog(
+                    title = stringResource(R.string.settings_world_clock_edit_city),
+                    initialLabel = city.label,
+                    initialTimeZoneId = city.timeZoneId,
+                    onDismiss = { editingCityId = null },
+                    onSave = { label, zone ->
+                        if (viewModel.updateWorldClockCity(city.id, label, zone)) {
+                            editingCityId = null
+                        }
+                    },
+            )
+        }
+    }
+
+    editingCountdownId?.let { eventId ->
+        val event = eventsById[eventId]
+        if (event != null) {
+            CountdownEditDialog(
+                    initialTitle = event.title,
+                    initialEpochMillis = event.targetEpochMillis,
+                    onDismiss = { editingCountdownId = null },
+                    onSave = { title, epochMillis ->
+                        if (viewModel.saveCountdownEvent(event.id, title, epochMillis)) {
+                            editingCountdownId = null
+                        }
+                    },
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/SettingsControls.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/SettingsControls.kt
@@ -1,0 +1,1112 @@
+package com.lu4p.fokuslauncher.ui.settings
+
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.res.Resources
+import android.net.Uri
+import android.os.Build
+import android.widget.Toast
+import android.provider.Settings
+import androidx.activity.compose.LocalActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ChatBubble
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material.icons.outlined.Translate
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.lu4p.fokuslauncher.R
+import com.lu4p.fokuslauncher.data.model.AppInfo
+import com.lu4p.fokuslauncher.data.model.AppShortcutAction
+import com.lu4p.fokuslauncher.data.model.DrawerAppSortMode
+import com.lu4p.fokuslauncher.data.model.HomeAlignment
+import com.lu4p.fokuslauncher.data.model.HomeDateFormatStyle
+import com.lu4p.fokuslauncher.data.model.LauncherFontPreferences
+import com.lu4p.fokuslauncher.data.model.LauncherFontScale
+import com.lu4p.fokuslauncher.data.model.LauncherVisualStyle
+import com.lu4p.fokuslauncher.data.model.NotificationIndicatorColorPreset
+import com.lu4p.fokuslauncher.data.model.NotificationIndicatorStyle
+import com.lu4p.fokuslauncher.data.model.PhotoWallpaperDrawerOverlayIntensity
+import com.lu4p.fokuslauncher.data.model.PhotoWallpaperOutlineWidthDp
+import com.lu4p.fokuslauncher.data.model.ShortcutTarget
+import com.lu4p.fokuslauncher.data.model.TemperatureUnit
+import com.lu4p.fokuslauncher.data.model.WidgetTapTarget
+import com.lu4p.fokuslauncher.ui.components.FokusIconButton
+import com.lu4p.fokuslauncher.ui.components.FokusTextButton
+import com.lu4p.fokuslauncher.ui.components.LauncherIcon
+import com.lu4p.fokuslauncher.ui.settings.components.SettingsDropdown
+import com.lu4p.fokuslauncher.ui.settings.components.SettingsRow
+import com.lu4p.fokuslauncher.ui.settings.components.EmptySettingsStateText
+import com.lu4p.fokuslauncher.ui.settings.components.SectionHeader
+import com.lu4p.fokuslauncher.ui.theme.LocalLauncherFontScale
+import com.lu4p.fokuslauncher.ui.theme.LocalLauncherIconGlow
+import com.lu4p.fokuslauncher.ui.theme.composeFontFamilyFromStoredName
+import com.lu4p.fokuslauncher.ui.theme.launcherIconDp
+import com.lu4p.fokuslauncher.ui.theme.settingsPreviewColor
+import com.lu4p.fokuslauncher.ui.theme.withoutLauncherTextGlow
+import com.lu4p.fokuslauncher.ui.util.OnResumeEffect
+import com.lu4p.fokuslauncher.ui.util.formatShortcutTargetDisplay
+import com.lu4p.fokuslauncher.ui.util.rememberBooleanChangeWithSystemSound
+import com.lu4p.fokuslauncher.ui.util.rememberClickWithSystemSound
+import java.text.Collator
+import java.util.Locale
+import kotlinx.coroutines.launch
+
+internal data class SubpageNavRow(
+        @param:StringRes val labelRes: Int,
+        val subtitle: String? = null,
+        val onClick: () -> Unit,
+)
+
+internal data class SwipeTargetPick(
+        val pickerKey: String,
+        @param:StringRes val labelRes: Int,
+        val target: ShortcutTarget?,
+        val onClear: () -> Unit,
+)
+
+internal data class WidgetTapPickerRow(
+        @param:StringRes val labelRes: Int,
+        val tapTarget: WidgetTapTarget?,
+        val pickerKey: String,
+        val onClear: () -> Unit,
+        val emptyLabel: (Context, Resources) -> String = ::formatWidgetAppEmptyLabel,
+)
+
+internal data class DeviceControlToggleRow(
+        @param:StringRes val labelRes: Int,
+        val subtitle: String,
+        val checked: Boolean,
+        val onCheckedChange: (Boolean) -> Unit,
+)
+
+internal data class CommunityLink(
+        val icon: ImageVector,
+        val titleRes: Int,
+        val subtitleRes: Int,
+        val url: String,
+)
+
+internal val communityLinks =
+        listOf(
+                CommunityLink(
+                        Icons.Filled.Star,
+                        R.string.settings_github_title,
+                        R.string.settings_github_subtitle,
+                        "https://github.com/luantak/FokusLauncher",
+                ),
+                CommunityLink(
+                        Icons.Outlined.Translate,
+                        R.string.settings_weblate_title,
+                        R.string.settings_weblate_subtitle,
+                        "https://hosted.weblate.org/engage/fokus-launcher/",
+                ),
+                CommunityLink(
+                        Icons.Filled.ChatBubble,
+                        R.string.settings_matrix_title,
+                        R.string.settings_matrix_subtitle,
+                        "https://matrix.to/#/#fokus:matrix.org",
+                ),
+        )
+
+internal fun Context.hasCoarseLocationPermission(): Boolean =
+        ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) ==
+                PackageManager.PERMISSION_GRANTED
+
+internal fun <T> LazyListScope.manageableAppsSection(
+        headerRes: Int,
+        emptyTextRes: Int,
+        apps: List<T>,
+        key: (T) -> Any,
+        label: (T) -> String,
+        subtitle: (T) -> String,
+        onRowClick: (T) -> Unit,
+        trailingContent: @Composable RowScope.(T) -> Unit,
+) {
+    item { SectionHeader(stringResource(headerRes)) }
+    if (apps.isEmpty()) {
+        item { EmptySettingsStateText(text = stringResource(emptyTextRes)) }
+    } else {
+        items(apps, key = key) { app ->
+            SettingsRow(
+                    label = label(app),
+                    subtitle = subtitle(app),
+                    subtitleStyle = MaterialTheme.typography.labelMedium,
+                    onClick = { onRowClick(app) },
+                    trailing = { trailingContent(app) },
+            )
+        }
+    }
+}
+
+@Composable
+internal fun rememberCoarseLocationPermission(context: Context, activity: Activity?): Pair<Boolean, () -> Unit> {
+    var granted by remember { mutableStateOf(context.hasCoarseLocationPermission()) }
+    val lifecycleOwner = LocalLifecycleOwner.current
+    OnResumeEffect(lifecycleOwner) { granted = context.hasCoarseLocationPermission() }
+    val launcher =
+            rememberLauncherForActivityResult(
+                    contract = ActivityResultContracts.RequestPermission(),
+            ) {
+                granted = context.hasCoarseLocationPermission()
+                if (!granted &&
+                                activity != null &&
+                                !ActivityCompat.shouldShowRequestPermissionRationale(
+                                        activity,
+                                        Manifest.permission.ACCESS_COARSE_LOCATION,
+                                )
+                ) {
+                    context.startActivity(
+                            Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                                data = Uri.fromParts("package", context.packageName, null)
+                                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                            }
+                    )
+                }
+            }
+    val request = remember(launcher) { { launcher.launch(Manifest.permission.ACCESS_COARSE_LOCATION) } }
+    return granted to request
+}
+
+/**
+ * Endonym: name of the language written in that language (e.g. English, Polski), independent of
+ * app UI locale.
+ */
+internal fun languageAutonym(localeTag: String, allTags: List<String>): String {
+    val locale = Locale.forLanguageTag(localeTag)
+    val sameLanguageTags =
+            allTags.filter { Locale.forLanguageTag(it).language == locale.language }
+    val displayLocale =
+            when {
+                sameLanguageTags.size <= 1 -> locale
+                localeTag == "pt" -> Locale("pt", "PT")
+                else -> locale
+            }
+    val raw =
+            if (sameLanguageTags.size > 1) {
+                displayLocale.getDisplayName(displayLocale).trim()
+            } else {
+                locale.getDisplayLanguage(locale).trim()
+            }
+    if (raw.isBlank()) return localeTag
+    return raw.replaceFirstChar { ch ->
+        if (ch.isLowerCase()) ch.titlecase(displayLocale) else ch.toString()
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun HomeDateFormatDropdown(
+        currentStyle: HomeDateFormatStyle,
+        enabled: Boolean,
+        onStyleSelected: (HomeDateFormatStyle) -> Unit
+) {
+    val options = remember { HomeDateFormatStyle.entries }
+    var expanded by remember { mutableStateOf(false) }
+    val onDateFormatExpandedChange =
+            rememberBooleanChangeWithSystemSound { newExpanded ->
+                if (enabled) expanded = newExpanded
+            }
+    SettingsDropdown(
+            title = stringResource(R.string.settings_home_date_format),
+            options = options,
+            expanded = expanded,
+            onExpandedChange = onDateFormatExpandedChange,
+            selectedDisplayText = stringResource(currentStyle.labelRes),
+            fieldEnabled = enabled,
+            menuExpanded = expanded && enabled,
+            itemContent = { style ->
+                Text(
+                        text = stringResource(style.labelRes),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onBackground,
+                )
+            },
+            onItemSelected = onStyleSelected,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun TemperatureUnitDropdown(
+        currentUnit: TemperatureUnit,
+        enabled: Boolean,
+        onUnitSelected: (TemperatureUnit) -> Unit
+) {
+    val options = remember { TemperatureUnit.entries }
+    var expanded by remember { mutableStateOf(false) }
+    val onExpandedChange =
+            rememberBooleanChangeWithSystemSound { newExpanded ->
+                if (enabled) expanded = newExpanded
+            }
+    SettingsDropdown(
+            title = stringResource(R.string.settings_temperature_unit),
+            options = options,
+            expanded = expanded,
+            onExpandedChange = onExpandedChange,
+            selectedDisplayText = stringResource(currentUnit.labelRes),
+            fieldEnabled = enabled,
+            menuExpanded = expanded && enabled,
+            itemContent = { unit ->
+                Text(
+                        text = stringResource(unit.labelRes),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onBackground,
+                )
+            },
+            onItemSelected = onUnitSelected,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun NotificationIndicatorStyleDropdown(
+        currentStyle: NotificationIndicatorStyle,
+        onStyleSelected: (NotificationIndicatorStyle) -> Unit,
+) {
+    val options = remember { NotificationIndicatorStyle.entries }
+    var expanded by remember { mutableStateOf(false) }
+    val onExpandedChange = rememberBooleanChangeWithSystemSound { expanded = it }
+    SettingsDropdown(
+            title = stringResource(R.string.settings_notification_indicator_style),
+            options = options,
+            expanded = expanded,
+            onExpandedChange = onExpandedChange,
+            selectedDisplayText = stringResource(currentStyle.labelRes),
+            itemContent = { style ->
+                Text(
+                        text = stringResource(style.labelRes),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onBackground,
+                )
+            },
+            onItemSelected = onStyleSelected,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun NotificationIndicatorColorDropdown(
+        currentColor: Int,
+        onColorSelected: (NotificationIndicatorColorPreset) -> Unit,
+) {
+    val options = remember { NotificationIndicatorColorPreset.entries }
+    val currentPreset = remember(currentColor) {
+        NotificationIndicatorColorPreset.fromArgb(currentColor)
+    }
+    var expanded by remember { mutableStateOf(false) }
+    val onExpandedChange = rememberBooleanChangeWithSystemSound { expanded = it }
+    SettingsDropdown(
+            title = stringResource(R.string.settings_notification_indicator_color),
+            options = options,
+            expanded = expanded,
+            onExpandedChange = onExpandedChange,
+            selectedDisplayText = stringResource(currentPreset.labelRes),
+            fieldTextColor = Color(currentPreset.argb),
+            menuItemTextColor = { Color(it.argb) },
+            itemContent = { preset ->
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(
+                            modifier =
+                                    Modifier.size(12.dp)
+                                            .background(Color(preset.argb), CircleShape),
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                            text = stringResource(preset.labelRes),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = Color(preset.argb),
+                    )
+                }
+            },
+            onItemSelected = onColorSelected,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun AppLanguageDropdown(
+        currentTag: String,
+        onTagSelected: (String) -> Unit
+) {
+    val systemDefaultLabel = stringResource(R.string.settings_language_system_default)
+    val supportedLocaleTags =
+            remember {
+                listOf(
+                        "ca",
+                        "da",
+                        "de",
+                        "en",
+                        "es",
+                        "eu",
+                        "fi",
+                        "fr",
+                        "in",
+                        "it",
+                        "pl",
+                        "pt",
+                        "pt-BR",
+                        "ro",
+                        "ru",
+                        "ta",
+                        "tr",
+                        "uk",
+                        "zh-CN",
+                )
+            }
+    val options =
+            remember(systemDefaultLabel) {
+                val collator = Collator.getInstance(Locale.ROOT).apply { strength = Collator.PRIMARY }
+                buildList {
+                    add("" to systemDefaultLabel)
+                    supportedLocaleTags
+                            .map { tag -> tag to languageAutonym(tag, supportedLocaleTags) }
+                            .sortedWith { a, b -> collator.compare(a.second, b.second) }
+                            .forEach { add(it) }
+                }
+            }
+    var expanded by remember { mutableStateOf(false) }
+    val onLanguageExpandedChange = rememberBooleanChangeWithSystemSound { expanded = it }
+    val selectedDisplayText =
+            options.find { (tag, _) -> tag == currentTag }?.second
+                    ?: if (currentTag.isBlank()) {
+                        systemDefaultLabel
+                    } else {
+                        languageAutonym(currentTag, supportedLocaleTags)
+                    }
+    SettingsDropdown(
+            title = stringResource(R.string.settings_language_label),
+            options = options,
+            expanded = expanded,
+            onExpandedChange = onLanguageExpandedChange,
+            selectedDisplayText = selectedDisplayText,
+            itemContent = { (_, label) ->
+                Text(
+                        text = label,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onBackground,
+                )
+            },
+            onItemSelected = { (storageTag, _) -> onTagSelected(storageTag) },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun LauncherFontFamilyDropdown(
+        currentFamilyName: String,
+        installedFamilies: List<String>,
+        hasCustomFontFile: Boolean,
+        customFontDisplayName: String,
+        resolveCustomFontFile: (String) -> java.io.File?,
+        onFamilySelected: (String) -> Unit
+) {
+    val systemDefault = stringResource(R.string.settings_weather_app_system_default)
+    val customImportedFallback = stringResource(R.string.settings_font_custom_imported)
+    val customFontLabel =
+            customFontDisplayName.trim().ifBlank { customImportedFallback }
+    val options =
+            remember(
+                    currentFamilyName,
+                    installedFamilies,
+                    systemDefault,
+                    hasCustomFontFile,
+                    customFontLabel,
+            ) {
+                buildList {
+                    add("" to systemDefault)
+                    if (hasCustomFontFile) {
+                        add(LauncherFontPreferences.CUSTOM_FONT_STORAGE to customFontLabel)
+                    }
+                    val sorted = installedFamilies.sortedWith(String.CASE_INSENSITIVE_ORDER)
+                    sorted.forEach { add(it to it) }
+                    val cur = currentFamilyName.trim()
+                    if (cur.isNotEmpty() &&
+                                    sorted.none { it.equals(cur, ignoreCase = true) } &&
+                                    !(hasCustomFontFile &&
+                                            cur == LauncherFontPreferences.CUSTOM_FONT_STORAGE)
+                    ) {
+                        val label =
+                                if (LauncherFontPreferences.isCustomFont(cur)) {
+                                    customFontLabel
+                                } else {
+                                    cur
+                                }
+                        add(cur to label)
+                    }
+                }
+            }
+    var expanded by remember { mutableStateOf(false) }
+    val onFontExpandedChange = rememberBooleanChangeWithSystemSound { expanded = it }
+    val selectedLabel =
+            options.find { (value, _) -> value == currentFamilyName }?.second
+                    ?: currentFamilyName.ifBlank { systemDefault }
+    SettingsDropdown(
+            title = stringResource(R.string.settings_font_label),
+            options = options,
+            expanded = expanded,
+            onExpandedChange = onFontExpandedChange,
+            selectedDisplayText = selectedLabel,
+            textStyle =
+                    MaterialTheme.typography.bodyLarge.copy(
+                            fontFamily =
+                                    composeFontFamilyFromStoredName(currentFamilyName) {
+                                        resolveCustomFontFile(it)
+                                    }
+                    ),
+            itemContent = { (storageValue, label) ->
+                Text(
+                        text = label,
+                        style =
+                                MaterialTheme.typography.bodyLarge.copy(
+                                        fontFamily =
+                                                composeFontFamilyFromStoredName(storageValue) {
+                                                    resolveCustomFontFile(it)
+                                                }
+                                ),
+                        color = MaterialTheme.colorScheme.onBackground,
+                )
+            },
+            onItemSelected = { (storageValue, _) -> onFamilySelected(storageValue) },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun LauncherFontSizeSlider(
+        currentScale: Float,
+        onScaleChange: (Float) -> Unit,
+) {
+    val synced = LauncherFontScale.snapToStep(currentScale)
+    var pending by remember { mutableFloatStateOf(synced) }
+    LaunchedEffect(synced) { pending = synced }
+
+    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 12.dp)) {
+        Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                    text = stringResource(R.string.settings_font_size_label),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    modifier = Modifier.weight(1f),
+            )
+            Text(
+                    text = String.format(Locale.US, "%.1fx", pending),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.primary,
+            )
+        }
+        Spacer(Modifier.height(4.dp))
+        Text(
+                text = stringResource(R.string.settings_font_size_subtitle),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.secondary,
+        )
+        Spacer(Modifier.height(12.dp))
+        Slider(
+                value = pending,
+                onValueChange = { raw ->
+                    pending = LauncherFontScale.snapToStep(raw)
+                },
+                onValueChangeFinished = {
+                    val v = LauncherFontScale.snapToStep(pending)
+                    if (v != synced) {
+                        onScaleChange(v)
+                    }
+                },
+                valueRange = LauncherFontScale.MIN..LauncherFontScale.MAX,
+                steps = LauncherFontScale.SLIDER_STEPS,
+                modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun PhotoWallpaperOutlineWidthSlider(
+        currentWidthDp: Float,
+        onWidthDpChange: (Float) -> Unit,
+) {
+    val synced = PhotoWallpaperOutlineWidthDp.snapToStep(currentWidthDp)
+    var pending by remember { mutableFloatStateOf(synced) }
+    LaunchedEffect(synced) { pending = synced }
+
+    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 12.dp)) {
+        Text(
+                text = stringResource(R.string.settings_photo_outline_strength_label),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onBackground,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+                text = stringResource(R.string.settings_photo_outline_strength_subtitle),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.secondary,
+        )
+        Spacer(Modifier.height(12.dp))
+        Slider(
+                value = pending,
+                onValueChange = { raw ->
+                    pending = raw.coerceIn(PhotoWallpaperOutlineWidthDp.MIN, PhotoWallpaperOutlineWidthDp.MAX)
+                },
+                onValueChangeFinished = {
+                    val v = PhotoWallpaperOutlineWidthDp.snapToStep(pending)
+                    if (v != synced) {
+                        onWidthDpChange(v)
+                    }
+                },
+                valueRange = PhotoWallpaperOutlineWidthDp.MIN..PhotoWallpaperOutlineWidthDp.MAX,
+                steps = PhotoWallpaperOutlineWidthDp.SLIDER_STEPS,
+                modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun PhotoWallpaperDrawerOverlaySlider(
+        currentIntensity: Float,
+        onIntensityChange: (Float) -> Unit,
+) {
+    val synced = PhotoWallpaperDrawerOverlayIntensity.snapToStep(currentIntensity)
+    var pending by remember { mutableFloatStateOf(synced) }
+    LaunchedEffect(synced) { pending = synced }
+
+    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 12.dp)) {
+        Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                    text = stringResource(R.string.settings_photo_drawer_overlay_label),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    modifier = Modifier.weight(1f),
+            )
+            Text(
+                    text = String.format(Locale.US, "%.1fx", pending),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.primary,
+            )
+        }
+        Spacer(Modifier.height(4.dp))
+        Text(
+                text = stringResource(R.string.settings_photo_drawer_overlay_subtitle),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.secondary,
+        )
+        Spacer(Modifier.height(12.dp))
+        Slider(
+                value = pending,
+                onValueChange = { raw ->
+                    pending = PhotoWallpaperDrawerOverlayIntensity.snapToStep(raw)
+                },
+                onValueChangeFinished = {
+                    val v = PhotoWallpaperDrawerOverlayIntensity.snapToStep(pending)
+                    if (v != synced) {
+                        onIntensityChange(v)
+                    }
+                },
+                valueRange =
+                        PhotoWallpaperDrawerOverlayIntensity.MIN..PhotoWallpaperDrawerOverlayIntensity.MAX,
+                steps = PhotoWallpaperDrawerOverlayIntensity.SLIDER_STEPS,
+                modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun LauncherVisualStyleDropdown(
+        currentStyle: LauncherVisualStyle,
+        onStyleSelected: (LauncherVisualStyle) -> Unit,
+        homeUsesPhotoWallpaper: Boolean,
+) {
+    val options = remember { LauncherVisualStyle.entries.toList() }
+    var expanded by remember { mutableStateOf(false) }
+    val onExpandedChange = rememberBooleanChangeWithSystemSound { expanded = it }
+    LaunchedEffect(homeUsesPhotoWallpaper) {
+        if (homeUsesPhotoWallpaper) expanded = false
+    }
+    val displayStyle =
+            if (homeUsesPhotoWallpaper) LauncherVisualStyle.CLASSIC else currentStyle
+    val selectedLabel = stringResource(displayStyle.labelRes)
+    val fieldPreviewColor = displayStyle.settingsPreviewColor()
+    val lockedSubtitle = stringResource(R.string.settings_look_locked_image_wallpaper)
+    val normalSubtitle = stringResource(R.string.settings_visual_style_subtitle)
+    val menuGlowEnabled = LocalLauncherIconGlow.current.enabled
+    val menuFontBlurBoost =
+            LocalLauncherFontScale.current.coerceIn(LauncherFontScale.MIN, LauncherFontScale.MAX)
+                    .coerceIn(0.85f, 1.45f)
+    SettingsDropdown(
+            title = stringResource(R.string.settings_visual_style_label),
+            subtitle = if (homeUsesPhotoWallpaper) lockedSubtitle else normalSubtitle,
+            options = options,
+            expanded = expanded,
+            onExpandedChange = onExpandedChange,
+            fieldEnabled = !homeUsesPhotoWallpaper,
+            selectedDisplayText = selectedLabel,
+            fieldTextColor = fieldPreviewColor,
+            menuItemTextColor = { it.settingsPreviewColor() },
+            itemContent = { style ->
+                val preview = style.settingsPreviewColor()
+                val itemTextStyle =
+                        if (menuGlowEnabled) {
+                            MaterialTheme.typography.bodyLarge.copy(
+                                    color = Color.Unspecified,
+                                    shadow =
+                                            Shadow(
+                                                    color = preview.copy(alpha = 1f),
+                                                    offset = Offset.Zero,
+                                                    blurRadius = 40f * menuFontBlurBoost,
+                                            ),
+                            )
+                        } else {
+                            MaterialTheme.typography.bodyLarge
+                                    .copy(color = Color.Unspecified)
+                                    .withoutLauncherTextGlow()
+                        }
+                Text(
+                        text = stringResource(style.labelRes),
+                        style = itemTextStyle,
+                        color = preview,
+                )
+            },
+            onItemSelected = onStyleSelected,
+    )
+}
+
+@Composable
+internal fun SettingsLabeledSegmentedSection(
+        title: String,
+        subtitle: String?,
+        content: @Composable () -> Unit
+) {
+    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 12.dp)) {
+        Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onBackground
+        )
+        if (subtitle != null) {
+            Spacer(Modifier.height(4.dp))
+            Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.secondary
+            )
+        }
+        Spacer(Modifier.height(12.dp))
+        content()
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun DrawerCategoryRailSideRow(
+        railOnLeft: Boolean,
+        onRailOnLeftChanged: (Boolean) -> Unit
+) {
+    SettingsLabeledSegmentedSection(
+            title = stringResource(R.string.settings_drawer_category_rail_side),
+            subtitle = stringResource(R.string.settings_drawer_category_rail_side_subtitle),
+    ) {
+        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+            SegmentedButton(
+                    selected = railOnLeft,
+                    onClick =
+                            rememberClickWithSystemSound { onRailOnLeftChanged(true) },
+                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+                    icon = {},
+            ) {
+                Text(stringResource(R.string.settings_drawer_rail_position_left))
+            }
+            SegmentedButton(
+                    selected = !railOnLeft,
+                    onClick =
+                            rememberClickWithSystemSound { onRailOnLeftChanged(false) },
+                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+                    icon = {},
+            ) {
+                Text(stringResource(R.string.settings_drawer_rail_position_right))
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun DrawerAppSortRow(
+        currentMode: DrawerAppSortMode,
+        showCustomSortOption: Boolean,
+        onModeChanged: (DrawerAppSortMode) -> Unit
+) {
+    val modes =
+            remember(showCustomSortOption) {
+                if (showCustomSortOption) DrawerAppSortMode.entries.toList()
+                else DrawerAppSortMode.entries.filterNot { it == DrawerAppSortMode.CUSTOM }
+            }
+    val coercedMode =
+            remember(currentMode, showCustomSortOption, modes) {
+                if (!showCustomSortOption && currentMode == DrawerAppSortMode.CUSTOM) {
+                    DrawerAppSortMode.ALPHABETICAL
+                } else {
+                    currentMode
+                }
+            }
+    SettingsLabeledSegmentedSection(
+            title = stringResource(R.string.settings_drawer_app_sort),
+            subtitle = stringResource(R.string.settings_drawer_app_sort_subtitle),
+    ) {
+        SingleChoiceSegmentedButtonRow(
+                modifier =
+                        Modifier.fillMaxWidth()
+                                .height(IntrinsicSize.Max)
+        ) {
+            modes.forEachIndexed { index, mode ->
+                SegmentedButton(
+                        selected = coercedMode == mode,
+                        onClick = rememberClickWithSystemSound { onModeChanged(mode) },
+                        modifier = Modifier.weight(1f).fillMaxHeight(),
+                        shape =
+                                SegmentedButtonDefaults.itemShape(
+                                        index = index,
+                                        count = modes.size
+                                ),
+                        icon = {},
+                ) {
+                    Box(
+                            modifier = Modifier.fillMaxWidth().fillMaxHeight(),
+                            contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                                text = stringResource(mode.labelRes),
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                                textAlign = TextAlign.Center,
+                                modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun LongLockThresholdRow(
+        currentMinutes: Int,
+        onMinutesSelected: (Int) -> Unit
+) {
+    val options = remember { listOf(1, 5, 15, 30) }
+    var expanded by remember { mutableStateOf(false) }
+    val onLongLockExpandedChange = rememberBooleanChangeWithSystemSound { expanded = it }
+    val selectedLabel =
+            pluralStringResource(
+                    R.plurals.settings_long_lock_duration_minutes,
+                    currentMinutes,
+                    currentMinutes
+            )
+    SettingsDropdown(
+            title = stringResource(R.string.settings_long_lock_duration),
+            subtitle = stringResource(R.string.settings_long_lock_duration_subtitle),
+            options = options,
+            expanded = expanded,
+            onExpandedChange = onLongLockExpandedChange,
+            selectedDisplayText = selectedLabel,
+            itemContent = { minutes ->
+                Text(
+                        text =
+                                pluralStringResource(
+                                        R.plurals.settings_long_lock_duration_minutes,
+                                        minutes,
+                                        minutes
+                                ),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onBackground
+                )
+            },
+            onItemSelected = onMinutesSelected,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun HomeAlignmentRow(
+        currentAlignment: HomeAlignment,
+        onAlignmentChanged: (HomeAlignment) -> Unit
+) {
+    SettingsLabeledSegmentedSection(
+            title = stringResource(R.string.home_alignment_title),
+            subtitle = stringResource(R.string.home_alignment_subtitle),
+    ) {
+        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+            HomeAlignment.entries.forEachIndexed { index, alignment ->
+                SegmentedButton(
+                        selected = currentAlignment == alignment,
+                        onClick =
+                                rememberClickWithSystemSound {
+                                    onAlignmentChanged(alignment)
+                                },
+                        shape = SegmentedButtonDefaults.itemShape(
+                                index = index,
+                                count = HomeAlignment.entries.size
+                        ),
+                        icon = {},
+                ) {
+                    Text(stringResource(alignment.labelRes))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun ExportLogsRow(
+        context: Context,
+        createLogShareIntent: suspend () -> Intent?
+) {
+    val scope = rememberCoroutineScope()
+    val activity = LocalActivity.current
+    val shareChooserTitle = stringResource(R.string.settings_export_logs_share_chooser)
+    val exportLogsFailedToast = stringResource(R.string.toast_export_logs_failed)
+    SettingsRow(
+            label = stringResource(R.string.settings_export_logs_title),
+            subtitle = stringResource(R.string.settings_export_logs_subtitle),
+            verticalPadding = 14.dp,
+            onClick = {
+                scope.launch {
+                    val shareIntent = createLogShareIntent()
+                    if (shareIntent != null && activity != null) {
+                        activity.startActivity(
+                                Intent.createChooser(shareIntent, shareChooserTitle)
+                        )
+                    } else {
+                        Toast.makeText(context, exportLogsFailedToast, Toast.LENGTH_SHORT).show()
+                    }
+                }
+            },
+    )
+}
+
+// --- Weather app (location gate + shortcut row) ---
+
+@Composable
+internal fun WeatherAppSettingRow(
+        hasCoarseLocationPermission: Boolean,
+        onRequestLocationPermission: () -> Unit,
+        context: Context,
+        resources: Resources,
+        preferredWeatherTap: WidgetTapTarget?,
+        allApps: List<AppInfo>,
+        allShortcutActions: List<AppShortcutAction>,
+        onPickApp: () -> Unit,
+        onClear: () -> Unit,
+) {
+    Column {
+        if (!hasCoarseLocationPermission) {
+            SettingsRow(
+                    label = stringResource(R.string.settings_weather_location_disabled),
+                    subtitle = stringResource(R.string.settings_weather_location_disabled_subtitle),
+                    onClick = onRequestLocationPermission,
+                    leading = {
+                        LauncherIcon(
+                                imageVector = Icons.Outlined.LocationOn,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                iconSize = 24.dp,
+                        )
+                    },
+                    trailing = {
+                        FokusTextButton(onClick = onRequestLocationPermission) {
+                            Text(stringResource(R.string.settings_weather_location_enable_button))
+                        }
+                    },
+            )
+        } else {
+            val weatherAppLabel =
+                    formatWidgetTapTarget(
+                            context = context,
+                            resources = resources,
+                            binding = preferredWeatherTap,
+                            allApps = allApps,
+                            allActions = allShortcutActions,
+                            emptyLabel = ::formatWeatherAppEmptyLabel,
+                    )
+            ShortcutTargetRow(
+                    label = stringResource(R.string.settings_weather_app),
+                    currentTarget = weatherAppLabel,
+                    onPickApp = onPickApp,
+                    onClear = onClear,
+            )
+        }
+    }
+}
+
+// --- Swipe shortcut row ---
+
+@Composable
+internal fun ShortcutTargetRow(
+        label: String,
+        currentTarget: String,
+        onPickApp: () -> Unit,
+        onClear: () -> Unit
+) {
+    Row(
+            verticalAlignment = Alignment.Top,
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 12.dp)
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                    label,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onBackground
+            )
+            Text(
+                    currentTarget,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.secondary
+            )
+        }
+        Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(top = 2.dp),
+        ) {
+            FokusIconButton(
+                    onClick = onPickApp,
+                    modifier = Modifier.size(36.dp.launcherIconDp()),
+            ) {
+                LauncherIcon(
+                        Icons.Outlined.Edit,
+                        stringResource(R.string.action_change),
+                        tint = MaterialTheme.colorScheme.primary,
+                        iconSize = 20.dp,
+                )
+            }
+            FokusIconButton(
+                    onClick = onClear,
+                    modifier = Modifier.size(36.dp.launcherIconDp()),
+            ) {
+                LauncherIcon(
+                        Icons.Default.Close,
+                        stringResource(R.string.action_clear),
+                        tint = MaterialTheme.colorScheme.error,
+                        iconSize = 18.dp,
+                )
+            }
+        }
+    }
+}
+
+// =====================  DIALOGS  =====================
+
+internal fun formatWidgetAppEmptyLabel(context: Context, resources: Resources): String =
+        resources.getString(R.string.settings_weather_app_system_default)
+
+internal fun formatWeatherAppEmptyLabel(context: Context, resources: Resources): String {
+    val hasSystemWeatherApp =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                Intent(Intent.ACTION_MAIN)
+                        .apply { addCategory(Intent.CATEGORY_APP_WEATHER) }
+                        .resolveActivity(context.packageManager) != null
+            } else {
+                false
+            }
+    return if (hasSystemWeatherApp) {
+        resources.getString(R.string.settings_weather_app_system_default)
+    } else {
+        resources.getString(R.string.settings_weather_app_not_configured)
+    }
+}
+
+internal fun formatWidgetTapTarget(
+        context: Context,
+        resources: Resources,
+        binding: WidgetTapTarget?,
+        allApps: List<AppInfo>,
+        allActions: List<AppShortcutAction>,
+        emptyLabel: (Context, Resources) -> String,
+): String {
+    if (binding == null) return emptyLabel(context, resources)
+    val resolvedLabel =
+            allActions.find {
+                it.target == binding.target && it.profileKey == binding.profileKey
+            }?.actionLabel
+    return formatShortcutTargetDisplay(
+            context = context,
+            target = binding.target,
+            allApps = allApps,
+            notSetLabel = emptyLabel(context, resources),
+            resolvedLauncherActionLabel = resolvedLabel,
+            profileKey = binding.profileKey,
+    )
+}
+
+internal fun formatShortcutTarget(
+        context: Context,
+        resources: Resources,
+        target: ShortcutTarget?,
+        allApps: List<AppInfo>
+): String {
+    return formatShortcutTargetDisplay(
+            context = context,
+            target = target,
+            allApps = allApps,
+            notSetLabel = resources.getString(R.string.shortcut_target_not_set),
+            resolvedLauncherActionLabel = null
+    )
+}

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/SettingsScreen.kt
@@ -1,328 +1,81 @@
 package com.lu4p.fokuslauncher.ui.settings
 
-import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.content.res.Resources
-import android.content.pm.PackageManager
-import android.net.Uri
 import android.os.Build
-import android.widget.Toast
-import android.provider.Settings
-import androidx.activity.compose.LocalActivity
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
-import com.lu4p.fokuslauncher.ui.components.AccessibilityProminentDisclosureOverlay
-import com.lu4p.fokuslauncher.ui.components.FokusIconButton
-import com.lu4p.fokuslauncher.ui.components.FokusTextButton
-import com.lu4p.fokuslauncher.ui.components.LauncherIcon
-import com.lu4p.fokuslauncher.ui.util.rememberBooleanChangeWithSystemSound
-import com.lu4p.fokuslauncher.ui.util.rememberClickWithSystemSound
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.NavigateNext
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
-import androidx.compose.material.icons.filled.ChatBubble
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Restore
-import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.filled.Visibility
-import androidx.compose.material.icons.outlined.Edit
-import androidx.compose.material.icons.outlined.LocationOn
-import androidx.compose.material.icons.outlined.Translate
-import com.lu4p.fokuslauncher.media.MediaNotificationHelper
-import com.lu4p.fokuslauncher.usage.UsageStatsHelper
-import com.lu4p.fokuslauncher.ui.components.FokusAlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
-import kotlinx.coroutines.launch
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shadow
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.runtime.rememberUpdatedState
-import com.lu4p.fokuslauncher.data.model.HomeExtraWidgetAddType
-import com.lu4p.fokuslauncher.data.model.HomeExtraWidgetEntry
-import com.lu4p.fokuslauncher.data.model.displayNameForTimeZoneId
-import com.lu4p.fokuslauncher.data.model.formatUtcOffsetLabel
-import com.lu4p.fokuslauncher.ui.home.formatCountdownDateTimeLabel
-import com.lu4p.fokuslauncher.ui.util.rememberLocallyReorderedList
-import com.lu4p.fokuslauncher.ui.util.rememberVerticalSlotReorderState
-import com.lu4p.fokuslauncher.ui.settings.components.EditorDragHandleReorderIcon
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import com.lu4p.fokuslauncher.R
-import com.lu4p.fokuslauncher.data.font.CustomFontImportFailure
-import com.lu4p.fokuslauncher.data.model.LauncherFontPreferences
-import com.lu4p.fokuslauncher.data.model.LauncherFontScale
-import com.lu4p.fokuslauncher.data.model.PhotoWallpaperDrawerOverlayIntensity
-import com.lu4p.fokuslauncher.data.model.PhotoWallpaperOutlineWidthDp
-import java.text.Collator
-import java.util.Locale
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.lu4p.fokuslauncher.data.model.AppInfo
+import com.lu4p.fokuslauncher.R
 import com.lu4p.fokuslauncher.data.model.AppShortcutAction
-import com.lu4p.fokuslauncher.data.model.DrawerAppSortMode
-import com.lu4p.fokuslauncher.data.model.HomeDateFormatStyle
-import com.lu4p.fokuslauncher.data.model.HomeAlignment
-import com.lu4p.fokuslauncher.data.model.NotificationIndicatorColorPreset
-import com.lu4p.fokuslauncher.data.model.NotificationIndicatorStyle
-import com.lu4p.fokuslauncher.data.model.TemperatureUnit
-import com.lu4p.fokuslauncher.data.model.LauncherVisualStyle
-import com.lu4p.fokuslauncher.data.model.ShortcutTarget
-import com.lu4p.fokuslauncher.data.model.WidgetTapTarget
-import com.lu4p.fokuslauncher.utils.LockScreenHelper
-import com.lu4p.fokuslauncher.ui.theme.FokusBackdrop
-import com.lu4p.fokuslauncher.ui.theme.LocalLauncherFontScale
-import com.lu4p.fokuslauncher.ui.theme.LocalLauncherIconGlow
-import com.lu4p.fokuslauncher.ui.theme.settingsPreviewColor
-import com.lu4p.fokuslauncher.ui.theme.withLauncherTextGlowRecolored
-import com.lu4p.fokuslauncher.ui.theme.withoutLauncherTextGlow
-import com.lu4p.fokuslauncher.ui.settings.components.SettingsDropdown
+import com.lu4p.fokuslauncher.ui.components.FokusAlertDialog
+import com.lu4p.fokuslauncher.ui.components.FokusTextButton
+import com.lu4p.fokuslauncher.ui.components.LauncherIcon
+import com.lu4p.fokuslauncher.ui.settings.components.SectionHeader
+import com.lu4p.fokuslauncher.ui.settings.components.SettingsDivider
 import com.lu4p.fokuslauncher.ui.settings.components.SettingsRow
-import com.lu4p.fokuslauncher.ui.settings.components.SettingsToggleRow
-import com.lu4p.fokuslauncher.ui.theme.composeFontFamilyFromStoredName
-import com.lu4p.fokuslauncher.ui.theme.launcherIconDp
-import com.lu4p.fokuslauncher.ui.util.OnResumeEffect
-import com.lu4p.fokuslauncher.ui.util.clickableWithSystemSound
-import com.lu4p.fokuslauncher.ui.util.formatShortcutTargetDisplay
-import android.app.Activity
-import androidx.annotation.StringRes
-
-private data class SubpageNavRow(
-        @param:StringRes val labelRes: Int,
-        val subtitle: String? = null,
-        val onClick: () -> Unit,
-)
-
-private data class SwipeTargetPick(
-        val pickerKey: String,
-        @param:StringRes val labelRes: Int,
-        val target: ShortcutTarget?,
-        val onClear: () -> Unit,
-)
-
-private data class WidgetTapPickerRow(
-        @param:StringRes val labelRes: Int,
-        val tapTarget: WidgetTapTarget?,
-        val pickerKey: String,
-        val onClear: () -> Unit,
-        val emptyLabel: (Context, Resources) -> String = ::formatWidgetAppEmptyLabel,
-)
-
-private data class DeviceControlToggleRow(
-        @param:StringRes val labelRes: Int,
-        val subtitle: String,
-        val checked: Boolean,
-        val onCheckedChange: (Boolean) -> Unit,
-)
-
-private data class CommunityLink(
-        val icon: ImageVector,
-        val titleRes: Int,
-        val subtitleRes: Int,
-        val url: String,
-)
-
-private val communityLinks =
-        listOf(
-                CommunityLink(
-                        Icons.Filled.Star,
-                        R.string.settings_github_title,
-                        R.string.settings_github_subtitle,
-                        "https://github.com/luantak/FokusLauncher",
-                ),
-                CommunityLink(
-                        Icons.Outlined.Translate,
-                        R.string.settings_weblate_title,
-                        R.string.settings_weblate_subtitle,
-                        "https://hosted.weblate.org/engage/fokus-launcher/",
-                ),
-                CommunityLink(
-                        Icons.Filled.ChatBubble,
-                        R.string.settings_matrix_title,
-                        R.string.settings_matrix_subtitle,
-                        "https://matrix.to/#/#fokus:matrix.org",
-                ),
-        )
-
-private fun Context.hasCoarseLocationPermission(): Boolean =
-        ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) ==
-                PackageManager.PERMISSION_GRANTED
-
-private fun <T> LazyListScope.manageableAppsSection(
-        headerRes: Int,
-        emptyTextRes: Int,
-        apps: List<T>,
-        key: (T) -> Any,
-        label: (T) -> String,
-        subtitle: (T) -> String,
-        onRowClick: (T) -> Unit,
-        trailingContent: @Composable RowScope.(T) -> Unit,
-) {
-    item { SectionHeader(stringResource(headerRes)) }
-    if (apps.isEmpty()) {
-        item { EmptySettingsStateText(text = stringResource(emptyTextRes)) }
-    } else {
-        items(apps, key = key) { app ->
-            SettingsRow(
-                    label = label(app),
-                    subtitle = subtitle(app),
-                    subtitleStyle = MaterialTheme.typography.labelMedium,
-                    onClick = { onRowClick(app) },
-                    trailing = { trailingContent(app) },
-            )
-        }
-    }
-}
-
-@Composable
-private fun rememberCoarseLocationPermission(context: Context, activity: Activity?): Pair<Boolean, () -> Unit> {
-    var granted by remember { mutableStateOf(context.hasCoarseLocationPermission()) }
-    val lifecycleOwner = LocalLifecycleOwner.current
-    OnResumeEffect(lifecycleOwner) { granted = context.hasCoarseLocationPermission() }
-    val launcher =
-            rememberLauncherForActivityResult(
-                    contract = ActivityResultContracts.RequestPermission(),
-            ) {
-                granted = context.hasCoarseLocationPermission()
-                if (!granted &&
-                                activity != null &&
-                                !ActivityCompat.shouldShowRequestPermissionRationale(
-                                        activity,
-                                        Manifest.permission.ACCESS_COARSE_LOCATION,
-                                )
-                ) {
-                    context.startActivity(
-                            Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-                                data = Uri.fromParts("package", context.packageName, null)
-                                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                            }
-                    )
-                }
-            }
-    val request = remember(launcher) { { launcher.launch(Manifest.permission.ACCESS_COARSE_LOCATION) } }
-    return granted to request
-}
+import com.lu4p.fokuslauncher.ui.settings.components.SubpageChevron
+import com.lu4p.fokuslauncher.ui.theme.FokusBackdrop
+import com.lu4p.fokuslauncher.ui.theme.withLauncherTextGlowRecolored
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
         viewModel: SettingsViewModel = hiltViewModel(),
         onNavigateBack: () -> Unit = {},
-        onNavigateToHome: () -> Unit = {},
         onEditHomeScreen: () -> Unit = {},
         onEditRightShortcuts: () -> Unit = {},
         onOpenDeviceControlSettings: () -> Unit = {},
         onEditCategories: () -> Unit = {},
         onDrawerDotSearchSettings: () -> Unit = {},
         onOpenHomeWidgetsSettings: () -> Unit = {},
-        backgroundScrim: Color = FokusBackdrop.ScrimColorWithoutBlur
+        onOpenAppearanceSettings: () -> Unit = {},
+        onOpenDrawerBehaviorSettings: () -> Unit = {},
+        onOpenAppsManagementSettings: () -> Unit = {},
+        backgroundScrim: Color = FokusBackdrop.ScrimColorWithoutBlur,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val installedFontFamilies by viewModel.installedFontFamilies.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val resources = LocalResources.current
 
-    // Dialog states
-    val showAppPickerFor = remember { mutableStateOf<String?>(null) } // swipeLeft/swipeRight
+    val showAppPickerFor = remember { mutableStateOf<String?>(null) }
     val showResetConfirm = remember { mutableStateOf(false) }
 
-    val wallpaperPickerLauncher = rememberLauncherForActivityResult(
-            contract = ActivityResultContracts.GetContent()
-    ) { uri: Uri? ->
-        uri?.let {
-            viewModel.setSystemWallpaper(it)
-            onNavigateToHome()
-        }
-    }
-
-    val fontImportFailedUnreadable =
-            stringResource(R.string.settings_font_import_failed_unreadable)
-    val fontImportFailedExtension =
-            stringResource(R.string.settings_font_import_failed_extension)
-    val fontImportFailedInvalid = stringResource(R.string.settings_font_import_failed_invalid)
-    val fontImportFailedIo = stringResource(R.string.settings_font_import_failed_io)
-    val fontPickerLauncher =
-            rememberLauncherForActivityResult(contract = ActivityResultContracts.OpenDocument()) {
-                    uri: Uri? ->
-                uri?.let { picked ->
-                    viewModel.importCustomFont(picked) { failure ->
-                        val message =
-                                when (failure) {
-                                    CustomFontImportFailure.UNREADABLE_URI ->
-                                            fontImportFailedUnreadable
-                                    CustomFontImportFailure.INVALID_EXTENSION ->
-                                            fontImportFailedExtension
-                                    CustomFontImportFailure.INVALID_FONT ->
-                                            fontImportFailedInvalid
-                                    CustomFontImportFailure.IO_ERROR -> fontImportFailedIo
-                                    null -> null
-                                }
-                        if (message != null) {
-                            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
-                        }
-                    }
-                }
-            }
-
-    Column(modifier = Modifier
-        .fillMaxSize()
-        .background(backgroundScrim)
-        .navigationBarsPadding()
-        .testTag("settings_screen")
+    Column(
+            modifier =
+                    Modifier.fillMaxSize()
+                            .background(backgroundScrim)
+                            .navigationBarsPadding()
+                            .testTag("settings_screen")
     ) {
         FokusSettingsTopBar(
                 titleText = stringResource(R.string.settings_title),
@@ -330,34 +83,20 @@ fun SettingsScreen(
                 containerColor = MaterialTheme.colorScheme.background,
         )
 
-        SettingsScreenContent(
+        SettingsHubContent(
                 viewModel = viewModel,
                 uiState = uiState,
-                installedFontFamilies = installedFontFamilies,
                 context = context,
                 resources = resources,
-                onPickWallpaper = { wallpaperPickerLauncher.launch("image/*") },
-                onImportCustomFont = {
-                    fontPickerLauncher.launch(
-                            arrayOf(
-                                    "font/ttf",
-                                    "application/x-font-ttf",
-                                    "application/font-sfnt",
-                                    "application/octet-stream",
-                            )
-                    )
-                },
-                resolveCustomFontFile = viewModel::resolveCustomFontFile,
-                onSetBlackWallpaper = {
-                    viewModel.setBlackWallpaper()
-                    onNavigateToHome()
-                },
+                onOpenAppearanceSettings = onOpenAppearanceSettings,
                 onOpenHomeWidgetsSettings = onOpenHomeWidgetsSettings,
                 onOpenDeviceControlSettings = onOpenDeviceControlSettings,
                 onEditHomeScreen = onEditHomeScreen,
                 onEditRightShortcuts = onEditRightShortcuts,
                 onEditCategories = onEditCategories,
                 onDrawerDotSearchSettings = onDrawerDotSearchSettings,
+                onOpenDrawerBehaviorSettings = onOpenDrawerBehaviorSettings,
+                onOpenAppsManagementSettings = onOpenAppsManagementSettings,
                 onShowAppPicker = { showAppPickerFor.value = it },
                 onShowResetConfirm = { showResetConfirm.value = true },
         )
@@ -383,22 +122,20 @@ fun SettingsScreen(
 }
 
 @Composable
-private fun SettingsScreenContent(
+private fun SettingsHubContent(
         viewModel: SettingsViewModel,
         uiState: SettingsUiState,
-        installedFontFamilies: List<String>,
         context: Context,
         resources: Resources,
-        onPickWallpaper: () -> Unit,
-        onImportCustomFont: () -> Unit,
-        resolveCustomFontFile: (String) -> java.io.File?,
-        onSetBlackWallpaper: () -> Unit,
+        onOpenAppearanceSettings: () -> Unit,
         onOpenHomeWidgetsSettings: () -> Unit,
         onOpenDeviceControlSettings: () -> Unit,
         onEditHomeScreen: () -> Unit,
         onEditRightShortcuts: () -> Unit,
         onEditCategories: () -> Unit,
         onDrawerDotSearchSettings: () -> Unit,
+        onOpenDrawerBehaviorSettings: () -> Unit,
+        onOpenAppsManagementSettings: () -> Unit,
         onShowAppPicker: (String) -> Unit,
         onShowResetConfirm: () -> Unit,
 ) {
@@ -428,7 +165,7 @@ private fun SettingsScreenContent(
                             pluralStringResource(
                                     R.plurals.settings_shortcuts_configured,
                                     uiState.rightSideShortcuts.size,
-                                    uiState.rightSideShortcuts.size
+                                    uiState.rightSideShortcuts.size,
                             ),
                             onEditRightShortcuts,
                     ),
@@ -444,7 +181,7 @@ private fun SettingsScreenContent(
                             pluralStringResource(
                                     R.plurals.settings_categories_count,
                                     editableCategoryCount,
-                                    editableCategoryCount
+                                    editableCategoryCount,
                             ),
                             onEditCategories,
                     ),
@@ -453,116 +190,37 @@ private fun SettingsScreenContent(
                             stringResource(R.string.settings_dot_search_subtitle),
                             onDrawerDotSearchSettings,
                     ),
+                    SubpageNavRow(
+                            R.string.settings_drawer_behavior_title,
+                            stringResource(R.string.settings_drawer_behavior_subtitle),
+                            onOpenDrawerBehaviorSettings,
+                    ),
             )
+    val managedAppsCount =
+            uiState.hiddenApps.size +
+                    uiState.renamedApps.size +
+                    if (Build.VERSION.SDK_INT >= 35) uiState.archivedApps.size else 0
+    val appsManagementSubtitle =
+            if (managedAppsCount == 0) {
+                stringResource(R.string.settings_apps_management_subtitle_empty)
+            } else {
+                pluralStringResource(
+                        R.plurals.settings_apps_management_count,
+                        managedAppsCount,
+                        managedAppsCount,
+                )
+            }
+
     LazyColumn(modifier = Modifier.fillMaxSize()) {
         item { SectionHeader(stringResource(R.string.settings_section_appearance)) }
-        items(
-                listOf(
-                        Triple(
-                                R.string.settings_show_status_bar,
-                                uiState.showStatusBar,
-                                viewModel::setShowStatusBar,
-                        ),
-                        Triple(
-                                R.string.settings_allow_landscape_rotation,
-                                uiState.allowLandscapeRotation,
-                                viewModel::setAllowLandscapeRotation,
-                        ),
-                ),
-                key = { it.first },
-        ) { (labelRes, checked, onChange) ->
-            SettingsToggleRow(
-                    label = stringResource(labelRes),
-                    checked = checked,
-                    onCheckedChange = onChange,
-            )
-        }
-        item {
-            AppLanguageDropdown(
-                    currentTag = uiState.appLocaleTag,
-                    onTagSelected = viewModel::setAppLocaleTag
-            )
-        }
-        item {
-            LauncherFontFamilyDropdown(
-                    currentFamilyName = uiState.launcherFontFamilyName,
-                    installedFamilies = installedFontFamilies,
-                    hasCustomFontFile = uiState.hasCustomFontFile,
-                    customFontDisplayName = uiState.customFontDisplayName,
-                    resolveCustomFontFile = resolveCustomFontFile,
-                    onFamilySelected = viewModel::setLauncherFontFamilyName
-            )
-        }
         item {
             SettingsRow(
-                    label = stringResource(R.string.settings_font_import_ttf),
-                    subtitle = stringResource(R.string.settings_font_import_ttf_subtitle),
+                    label = stringResource(R.string.settings_look_and_feel_title),
+                    subtitle = stringResource(R.string.settings_look_and_feel_subtitle),
                     verticalPadding = 14.dp,
-                    onClick = onImportCustomFont,
+                    onClick = onOpenAppearanceSettings,
+                    trailing = { SubpageChevron() },
             )
-        }
-        item {
-            LauncherFontSizeSlider(
-                    currentScale = uiState.launcherFontScale,
-                    onScaleChange = viewModel::setLauncherFontScale,
-            )
-        }
-        item {
-            LauncherVisualStyleDropdown(
-                    currentStyle = uiState.launcherVisualStyle,
-                    onStyleSelected = viewModel::setLauncherVisualStyle,
-                    homeUsesPhotoWallpaper = uiState.homeUsesPhotoWallpaper,
-            )
-        }
-        item {
-            SettingsToggleRow(
-                    label = stringResource(R.string.settings_glow_label),
-                    checked =
-                            uiState.launcherGlowEnabled && !uiState.homeUsesPhotoWallpaper,
-                    onCheckedChange = viewModel::setLauncherGlowEnabled,
-                    subtitle =
-                            stringResource(
-                                    if (uiState.homeUsesPhotoWallpaper) {
-                                        R.string.settings_look_locked_image_wallpaper
-                                    } else {
-                                        R.string.settings_glow_subtitle
-                                    }
-                            ),
-                    enabled = !uiState.homeUsesPhotoWallpaper,
-            )
-        }
-        item {
-            SettingsRow(
-                    label = stringResource(R.string.settings_set_background_image),
-                    verticalPadding = 14.dp,
-                    onClick = onPickWallpaper,
-            )
-        }
-        item {
-            SettingsRow(
-                    label = stringResource(R.string.settings_set_black_wallpaper),
-                    verticalPadding = 14.dp,
-                    onClick = onSetBlackWallpaper,
-            )
-        }
-        if (uiState.homeUsesPhotoWallpaper) {
-            item {
-                SectionHeader(
-                        stringResource(R.string.settings_section_image_wallpaper_accessibility)
-                )
-            }
-            item {
-                PhotoWallpaperOutlineWidthSlider(
-                        currentWidthDp = uiState.photoWallpaperOutlineWidthDp,
-                        onWidthDpChange = viewModel::setPhotoWallpaperOutlineWidthDp,
-                )
-            }
-            item {
-                PhotoWallpaperDrawerOverlaySlider(
-                        currentIntensity = uiState.photoWallpaperDrawerOverlayIntensity,
-                        onIntensityChange = viewModel::setPhotoWallpaperDrawerOverlayIntensity,
-                )
-            }
         }
         item { SettingsDivider() }
 
@@ -582,7 +240,7 @@ private fun SettingsScreenContent(
         item {
             HomeAlignmentRow(
                     currentAlignment = uiState.homeAlignment,
-                    onAlignmentChanged = viewModel::setHomeAlignment
+                    onAlignmentChanged = viewModel::setHomeAlignment,
             )
         }
         items(
@@ -607,7 +265,7 @@ private fun SettingsScreenContent(
                                     context,
                                     resources,
                                     row.target,
-                                    uiState.allApps
+                                    uiState.allApps,
                             ),
                     onPickApp = { onShowAppPicker(row.pickerKey) },
                     onClear = row.onClear,
@@ -628,121 +286,18 @@ private fun SettingsScreenContent(
                     trailing = { SubpageChevron() },
             )
         }
-        item {
-            SettingsToggleRow(
-                    label = stringResource(R.string.settings_drawer_search_auto_launch),
-                    subtitle = stringResource(R.string.settings_drawer_search_auto_launch_subtitle),
-                    checked = uiState.drawerSearchAutoLaunch,
-                    onCheckedChange = viewModel::setDrawerSearchAutoLaunch
-            )
-        }
-        if (!uiState.drawerSidebarCategories) {
-            item {
-                SettingsToggleRow(
-                        label = stringResource(R.string.settings_drawer_scroll_to_top_auto_keyboard),
-                        subtitle = stringResource(R.string.settings_drawer_scroll_to_top_auto_keyboard_subtitle),
-                        checked = uiState.drawerScrollToTopAutoKeyboard,
-                        onCheckedChange = viewModel::setDrawerScrollToTopAutoKeyboard
-                )
-            }
-        }
-        item {
-            SettingsToggleRow(
-                    label = stringResource(R.string.settings_drawer_sidebar_categories),
-                    subtitle = stringResource(R.string.settings_drawer_sidebar_categories_subtitle),
-                    checked = uiState.drawerSidebarCategories,
-                    onCheckedChange = viewModel::setDrawerSidebarCategories
-            )
-        }
-        if (uiState.drawerSidebarCategories) {
-            item {
-                DrawerCategoryRailSideRow(
-                        railOnLeft = uiState.drawerCategorySidebarOnLeft,
-                        onRailOnLeftChanged = viewModel::setDrawerCategorySidebarOnLeft
-                )
-            }
-        }
-        item {
-            DrawerAppSortRow(
-                    currentMode = uiState.drawerAppSortMode,
-                    showCustomSortOption = uiState.drawerSidebarCategories,
-                    onModeChanged = viewModel::setDrawerAppSortMode
-            )
-        }
         item { SettingsDivider() }
 
-        // System app archiving APIs (ApplicationInfo.isArchived, etc.) require API 35+.
-        if (Build.VERSION.SDK_INT >= 35) {
-            manageableAppsSection(
-                    headerRes = R.string.settings_section_archived_apps,
-                    emptyTextRes = R.string.settings_no_archived_apps,
-                    apps = uiState.archivedApps,
-                    key = { "archived_${it.stableKey}" },
-                    label = { it.app.label },
-                    subtitle = { archived ->
-                        archived.profileLabel?.let { pl -> "$pl • ${archived.app.packageName}" }
-                                ?: archived.app.packageName
-                    },
-                    onRowClick = viewModel::restoreArchivedApp,
-                    trailingContent = {
-                        Spacer(Modifier.width(8.dp))
-                        LauncherIcon(
-                                Icons.Default.Restore,
-                                stringResource(R.string.cd_restore_archived_app),
-                                tint = MaterialTheme.colorScheme.secondary,
-                                iconSize = 24.dp,
-                        )
-                    },
+        item { SectionHeader(stringResource(R.string.settings_section_apps)) }
+        item {
+            SettingsRow(
+                    label = stringResource(R.string.settings_apps_management_title),
+                    subtitle = appsManagementSubtitle,
+                    verticalPadding = 14.dp,
+                    onClick = onOpenAppsManagementSettings,
+                    trailing = { SubpageChevron() },
             )
-            item { SettingsDivider() }
         }
-
-        manageableAppsSection(
-                headerRes = R.string.settings_section_hidden_apps,
-                emptyTextRes = R.string.settings_no_hidden_apps,
-                apps = uiState.hiddenApps,
-                key = { "hidden_${it.stableKey}" },
-                label = { it.label },
-                subtitle = { app ->
-                    app.profileLabel?.let { pl -> "$pl • ${app.packageName}" } ?: app.packageName
-                },
-                onRowClick = {
-                    viewModel.unhideApp(it.packageName, it.profileKey, it.launcherShortcutId)
-                },
-                trailingContent = {
-                    Spacer(Modifier.width(8.dp))
-                    LauncherIcon(
-                            Icons.Default.Visibility,
-                            stringResource(R.string.cd_unhide_app),
-                            tint = MaterialTheme.colorScheme.secondary,
-                            iconSize = 24.dp,
-                    )
-                },
-        )
-        item { SettingsDivider() }
-
-        manageableAppsSection(
-                headerRes = R.string.settings_section_renamed_apps,
-                emptyTextRes = R.string.settings_no_renamed_apps,
-                apps = uiState.renamedApps,
-                key = { "renamed_${it.stableKey}" },
-                label = { it.customName },
-                subtitle = { app ->
-                    app.profileLabel?.let { pl -> "$pl • ${app.packageName}" } ?: app.packageName
-                },
-                onRowClick = {
-                    viewModel.removeRename(it.packageName, it.profileKey, it.launcherShortcutId)
-                },
-                trailingContent = {
-                    Spacer(Modifier.width(8.dp))
-                    LauncherIcon(
-                            Icons.Default.Close,
-                            stringResource(R.string.cd_remove_rename),
-                            tint = MaterialTheme.colorScheme.secondary,
-                            iconSize = 24.dp,
-                    )
-                },
-        )
         item { SettingsDivider() }
 
         item { SectionHeader(stringResource(R.string.settings_connect_section)) }
@@ -769,8 +324,9 @@ private fun SettingsScreenContent(
                     },
                     onClick = {
                         context.startActivity(
-                                Intent(Intent.ACTION_VIEW, link.url.toUri())
-                                        .apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
+                                Intent(Intent.ACTION_VIEW, link.url.toUri()).apply {
+                                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                }
                         )
                     },
             )
@@ -781,7 +337,7 @@ private fun SettingsScreenContent(
         item {
             ExportLogsRow(
                     context = context,
-                    createLogShareIntent = viewModel::createLogShareIntent
+                    createLogShareIntent = viewModel::createLogShareIntent,
             )
         }
         item {
@@ -822,12 +378,15 @@ private fun SettingsScreenDialogs(
         FokusAlertDialog(
                 onDismissRequest = onDismissResetConfirm,
                 title = {
-                    Text(stringResource(R.string.settings_reset_confirm_title), color = MaterialTheme.colorScheme.onBackground)
+                    Text(
+                            stringResource(R.string.settings_reset_confirm_title),
+                            color = MaterialTheme.colorScheme.onBackground,
+                    )
                 },
                 text = {
                     Text(
                             stringResource(R.string.settings_reset_confirm_message),
-                            color = MaterialTheme.colorScheme.onBackground
+                            color = MaterialTheme.colorScheme.onBackground,
                     )
                 },
                 confirmButton = {
@@ -853,7 +412,10 @@ private fun SettingsScreenDialogs(
                 },
                 dismissButton = {
                     FokusTextButton(onClick = onDismissResetConfirm) {
-                        Text(stringResource(R.string.action_cancel), color = MaterialTheme.colorScheme.primary)
+                        Text(
+                                stringResource(R.string.action_cancel),
+                                color = MaterialTheme.colorScheme.primary,
+                        )
                     }
                 },
         )
@@ -861,7 +423,8 @@ private fun SettingsScreenDialogs(
 
     pickerTarget?.let { target ->
         when (target) {
-            "swipeLeft", "swipeRight" -> {
+            "swipeLeft",
+            "swipeRight" -> {
                 ShortcutActionPickerDialog(
                         allActions = uiState.allShortcutActions,
                         allApps = uiState.allApps,
@@ -878,1571 +441,4 @@ private fun SettingsScreenDialogs(
             else -> onDismissPicker()
         }
     }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun HomeWidgetsSettingsScreen(
-        viewModel: SettingsViewModel = hiltViewModel(),
-        onNavigateBack: () -> Unit = {},
-        backgroundScrim: Color = FokusBackdrop.ScrimColorWithoutBlur
-) {
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val context = LocalContext.current
-    val resources = LocalResources.current
-    val activity = LocalActivity.current
-    val showAppPickerFor = remember { mutableStateOf<String?>(null) }
-
-    val (hasCoarseLocationPermission, requestCoarseLocation) =
-            rememberCoarseLocationPermission(context, activity)
-
-    var mediaNotificationAccessTick by remember { mutableIntStateOf(0) }
-    var pendingMediaEnable by remember { mutableStateOf(false) }
-    var pendingNotificationIndicatorsEnable by remember { mutableStateOf(false) }
-    var usageAccessTick by remember { mutableIntStateOf(0) }
-    var pendingScreenTimeEnable by remember { mutableStateOf(false) }
-    var showAddOtherWidget by remember { mutableStateOf(false) }
-    var editingCityId by remember { mutableStateOf<String?>(null) }
-    var pendingEditNewestCity by remember { mutableStateOf(false) }
-    var editingCountdownId by remember { mutableStateOf<String?>(null) }
-    var pendingEditNewestCountdown by remember { mutableStateOf(false) }
-    val lifecycleOwner = LocalLifecycleOwner.current
-    val extraWidgetsSource = uiState.homeExtraWidgets
-    val citiesById = remember(uiState.worldClockCities) { uiState.worldClockCities.associateBy { it.id } }
-    val eventsById = remember(uiState.countdownEvents) { uiState.countdownEvents.associateBy { it.id } }
-    val localExtras = rememberLocallyReorderedList(extraWidgetsSource)
-    val extraWidgets = localExtras.items
-    val reorderState = rememberVerticalSlotReorderState()
-    val onExtraCommit by rememberUpdatedState(viewModel::setHomeExtraWidgets)
-    OnResumeEffect(lifecycleOwner) {
-        mediaNotificationAccessTick++
-        usageAccessTick++
-    }
-    val mediaNotificationAccessEnabled =
-            remember(mediaNotificationAccessTick) {
-                MediaNotificationHelper.isListenerEnabled(context)
-            }
-    val usageAccessEnabled =
-            remember(usageAccessTick) { UsageStatsHelper.hasUsageAccess(context) }
-    LaunchedEffect(mediaNotificationAccessTick, uiState.showHomeMedia, pendingMediaEnable) {
-        if (pendingMediaEnable && mediaNotificationAccessEnabled) {
-            pendingMediaEnable = false
-            viewModel.setShowHomeMedia(true)
-        } else if (uiState.showHomeMedia && !mediaNotificationAccessEnabled) {
-            viewModel.setShowHomeMedia(false)
-        }
-    }
-    LaunchedEffect(
-            mediaNotificationAccessTick,
-            uiState.showNotificationIndicators,
-            pendingNotificationIndicatorsEnable,
-    ) {
-        if (pendingNotificationIndicatorsEnable && mediaNotificationAccessEnabled) {
-            pendingNotificationIndicatorsEnable = false
-            viewModel.setShowNotificationIndicators(true)
-        } else if (uiState.showNotificationIndicators && !mediaNotificationAccessEnabled) {
-            viewModel.setShowNotificationIndicators(false)
-        }
-    }
-    LaunchedEffect(usageAccessTick, uiState.showHomeScreenTime, pendingScreenTimeEnable) {
-        if (pendingScreenTimeEnable && usageAccessEnabled) {
-            pendingScreenTimeEnable = false
-            viewModel.setShowHomeScreenTime(true)
-        } else if (uiState.showHomeScreenTime && !usageAccessEnabled) {
-            viewModel.setShowHomeScreenTime(false)
-        }
-    }
-
-    Column(
-            modifier =
-                    Modifier.fillMaxSize()
-                            .background(backgroundScrim)
-                            .navigationBarsPadding()
-                            .testTag("home_widgets_settings_screen")
-    ) {
-        FokusSettingsTopBar(
-                titleText = stringResource(R.string.settings_home_widgets),
-                onNavigateBack = onNavigateBack,
-                containerColor = MaterialTheme.colorScheme.background,
-        )
-
-        LazyColumn(modifier = Modifier.fillMaxSize()) {
-            items(
-                    listOf(
-                            Triple(R.string.settings_show_home_clock, uiState.showHomeClock, viewModel::setShowHomeClock),
-                            Triple(R.string.settings_show_home_date, uiState.showHomeDate, viewModel::setShowHomeDate),
-                    ),
-                    key = { it.first },
-            ) { (labelRes, checked, onChange) ->
-                SettingsToggleRow(
-                        label = stringResource(labelRes),
-                        checked = checked,
-                        onCheckedChange = onChange,
-                )
-            }
-            item {
-                HomeDateFormatDropdown(
-                        currentStyle = uiState.homeDateFormatStyle,
-                        enabled = uiState.showHomeDate,
-                        onStyleSelected = viewModel::setHomeDateFormatStyle,
-                )
-            }
-            item {
-                TemperatureUnitDropdown(
-                        currentUnit = uiState.temperatureUnit,
-                        enabled = uiState.showHomeWeather || uiState.showWorldClockWeather,
-                        onUnitSelected = viewModel::setTemperatureUnit,
-                )
-            }
-            items(
-                    listOf(
-                            Triple(R.string.settings_show_home_weather, uiState.showHomeWeather, viewModel::setShowHomeWeather),
-                    ),
-                    key = { it.first },
-            ) { (labelRes, checked, onChange) ->
-                SettingsToggleRow(
-                        label = stringResource(labelRes),
-                        checked = checked,
-                        onCheckedChange = onChange,
-                )
-            }
-            item {
-                SettingsToggleRow(
-                        label = stringResource(R.string.settings_show_home_air_quality),
-                        subtitle =
-                                stringResource(R.string.settings_show_home_air_quality_subtitle),
-                        checked = uiState.showHomeAirQuality,
-                        enabled = uiState.showHomeWeather,
-                        onCheckedChange = viewModel::setShowHomeAirQuality,
-                )
-            }
-            item {
-                SettingsToggleRow(
-                        label = stringResource(R.string.settings_show_world_clock_weather),
-                        subtitle =
-                                stringResource(R.string.settings_show_world_clock_weather_subtitle),
-                        checked = uiState.showWorldClockWeather,
-                        onCheckedChange = viewModel::setShowWorldClockWeather,
-                )
-            }
-            item {
-                SettingsToggleRow(
-                        label = stringResource(R.string.settings_show_home_screen_time),
-                        subtitle =
-                                if (usageAccessEnabled) {
-                                    stringResource(R.string.settings_show_home_screen_time_subtitle)
-                                } else {
-                                    stringResource(
-                                            R.string.settings_show_home_screen_time_subtitle_grant_access
-                                    )
-                                },
-                        checked = uiState.showHomeScreenTime,
-                        onCheckedChange = { checked ->
-                            if (checked) {
-                                if (usageAccessEnabled) {
-                                    viewModel.setShowHomeScreenTime(true)
-                                } else {
-                                    pendingScreenTimeEnable = true
-                                    UsageStatsHelper.openUsageAccessSettings(context)
-                                }
-                            } else {
-                                pendingScreenTimeEnable = false
-                                viewModel.setShowHomeScreenTime(false)
-                            }
-                        },
-                )
-            }
-            items(
-                    listOf(
-                            Triple(R.string.settings_show_home_battery, uiState.showHomeBattery, viewModel::setShowHomeBattery),
-                    ),
-                    key = { it.first },
-            ) { (labelRes, checked, onChange) ->
-                SettingsToggleRow(
-                        label = stringResource(labelRes),
-                        checked = checked,
-                        onCheckedChange = onChange,
-                )
-            }
-            item {
-                SettingsToggleRow(
-                        label = stringResource(R.string.settings_show_home_media),
-                        subtitle =
-                                if (mediaNotificationAccessEnabled) {
-                                    stringResource(R.string.settings_show_home_media_subtitle)
-                                } else {
-                                    stringResource(R.string.settings_show_home_media_subtitle_grant_access)
-                                },
-                        checked = uiState.showHomeMedia,
-                        onCheckedChange = { checked ->
-                            if (checked) {
-                                if (mediaNotificationAccessEnabled) {
-                                    viewModel.setShowHomeMedia(true)
-                                } else {
-                                    pendingMediaEnable = true
-                                    MediaNotificationHelper.openListenerSettings(context)
-                                }
-                            } else {
-                                pendingMediaEnable = false
-                                viewModel.setShowHomeMedia(false)
-                            }
-                        },
-                )
-            }
-            item { SettingsDivider() }
-            item {
-                SettingsRow(
-                        label = stringResource(R.string.settings_home_extra_widgets),
-                        subtitle =
-                                if (extraWidgets.isEmpty()) {
-                                    stringResource(R.string.settings_home_extra_widgets_empty)
-                                } else {
-                                    null
-                                },
-                )
-            }
-            items(
-                    count = extraWidgets.size,
-                    key = { extraWidgets[it].stableKey },
-            ) { index ->
-                val entry = extraWidgets[index]
-                val title: String
-                val subtitle: String
-                when (entry) {
-                    is HomeExtraWidgetEntry.WorldClock -> {
-                        val city = citiesById[entry.cityId]
-                        title = city?.label ?: stringResource(R.string.settings_world_clock_cities)
-                        subtitle =
-                                if (city == null) {
-                                    stringResource(R.string.settings_world_clock_cities_empty)
-                                } else {
-                                    val zone = displayNameForTimeZoneId(city.timeZoneId)
-                                    val offset = formatUtcOffsetLabel(city.timeZoneId)
-                                    "$zone · $offset"
-                                }
-                    }
-                    is HomeExtraWidgetEntry.Countdown -> {
-                        val event = eventsById[entry.eventId]
-                        title = event?.title ?: stringResource(R.string.settings_countdown_event)
-                        subtitle =
-                                if (event == null) {
-                                    stringResource(R.string.settings_countdown_event_empty)
-                                } else {
-                                    formatCountdownDateTimeLabel(context, event)
-                                }
-                    }
-                }
-                Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier =
-                                Modifier.fillMaxWidth()
-                                        .heightIn(min = 56.dp)
-                                        .graphicsLayer {
-                                            translationY = reorderState.translationYForIndex(index)
-                                        }
-                                        .clickableWithSystemSound {
-                                            when (entry) {
-                                                is HomeExtraWidgetEntry.WorldClock ->
-                                                        editingCityId = entry.cityId
-                                                is HomeExtraWidgetEntry.Countdown ->
-                                                        editingCountdownId = entry.eventId
-                                            }
-                                        }
-                                        .padding(horizontal = 16.dp, vertical = 8.dp),
-                ) {
-                    EditorDragHandleReorderIcon(
-                            reorderState = reorderState,
-                            index = index,
-                            lastIndex = extraWidgets.lastIndex,
-                            onReorder = localExtras::reorder,
-                            onReset = {
-                                reorderState.reset {
-                                    localExtras.onDragEnd(onExtraCommit)
-                                }
-                            },
-                            entry.stableKey,
-                            extraWidgets.size,
-                            onDragGestureStart = localExtras::onDragStart,
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                                text = title,
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = MaterialTheme.colorScheme.onBackground,
-                        )
-                        Text(
-                                text = subtitle,
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.secondary,
-                        )
-                    }
-                    FokusTextButton(onClick = { viewModel.removeHomeExtraWidget(entry) }) {
-                        Text(stringResource(R.string.settings_remove_other_widget))
-                    }
-                }
-            }
-            item {
-                SettingsRow(
-                        label = stringResource(R.string.settings_add_other_widget),
-                        onClick = { showAddOtherWidget = true },
-                )
-            }
-            item { SettingsDivider() }
-            item {
-                SettingsToggleRow(
-                        label = stringResource(R.string.settings_notification_indicators),
-                        subtitle =
-                                if (mediaNotificationAccessEnabled) {
-                                    stringResource(R.string.settings_notification_indicators_subtitle)
-                                } else {
-                                    stringResource(
-                                            R.string.settings_notification_indicators_subtitle_grant_access
-                                    )
-                                },
-                        checked = uiState.showNotificationIndicators,
-                        onCheckedChange = { checked ->
-                            if (checked) {
-                                if (mediaNotificationAccessEnabled) {
-                                    viewModel.setShowNotificationIndicators(true)
-                                } else {
-                                    pendingNotificationIndicatorsEnable = true
-                                    MediaNotificationHelper.openListenerSettings(context)
-                                }
-                            } else {
-                                pendingNotificationIndicatorsEnable = false
-                                viewModel.setShowNotificationIndicators(false)
-                            }
-                        },
-                )
-            }
-            if (uiState.showNotificationIndicators) {
-                item {
-                    NotificationIndicatorStyleDropdown(
-                            currentStyle = uiState.notificationIndicatorStyle,
-                            onStyleSelected = viewModel::setNotificationIndicatorStyle,
-                    )
-                }
-                item {
-                    NotificationIndicatorColorDropdown(
-                            currentColor = uiState.notificationIndicatorColor,
-                            onColorSelected = viewModel::setNotificationIndicatorColorPreset,
-                    )
-                }
-            }
-            item { SettingsDivider() }
-            item {
-                WeatherAppSettingRow(
-                        hasCoarseLocationPermission = hasCoarseLocationPermission,
-                        onRequestLocationPermission = requestCoarseLocation,
-                        context = context,
-                        resources = resources,
-                        preferredWeatherTap = uiState.preferredWeatherTap,
-                        allApps = uiState.allApps,
-                        allShortcutActions = uiState.allShortcutActions,
-                        onPickApp = { showAppPickerFor.value = "weather" },
-                        onClear = { viewModel.setPreferredWeatherTap(null) },
-                )
-            }
-            items(
-                    listOf(
-                            WidgetTapPickerRow(
-                                    labelRes = R.string.settings_widget_clock_app,
-                                    tapTarget = uiState.preferredClockTap,
-                                    pickerKey = "clock",
-                                    onClear = { viewModel.setPreferredClockTap(null) },
-                            ),
-                            WidgetTapPickerRow(
-                                    labelRes = R.string.settings_widget_calendar_app,
-                                    tapTarget = uiState.preferredCalendarTap,
-                                    pickerKey = "calendar",
-                                    onClear = { viewModel.setPreferredCalendarTap(null) },
-                            ),
-                    ),
-                    key = { it.labelRes },
-            ) { row ->
-                ShortcutTargetRow(
-                        label = stringResource(row.labelRes),
-                        currentTarget =
-                                formatWidgetTapTarget(
-                                        context = context,
-                                        resources = resources,
-                                        binding = row.tapTarget,
-                                        allApps = uiState.allApps,
-                                        allActions = uiState.allShortcutActions,
-                                        emptyLabel = row.emptyLabel,
-                                ),
-                        onPickApp = { showAppPickerFor.value = row.pickerKey },
-                        onClear = row.onClear,
-                )
-            }
-        }
-    }
-
-    showAppPickerFor.value?.let { pickerTarget ->
-        ShortcutActionPickerDialog(
-                allActions = uiState.allShortcutActions,
-                allApps = uiState.allApps,
-                title = stringResource(R.string.edit_shortcuts_section_all_actions),
-                onSelect = { action ->
-                    when (pickerTarget) {
-                        "weather" -> viewModel.setPreferredWeatherTap(action)
-                        "clock" -> viewModel.setPreferredClockTap(action)
-                        "calendar" -> viewModel.setPreferredCalendarTap(action)
-                    }
-                    showAppPickerFor.value = null
-                },
-                onDismiss = { showAppPickerFor.value = null },
-                profileDisplayNameOverrides = uiState.profileDisplayNameOverrides,
-        )
-    }
-
-    if (showAddOtherWidget) {
-        FokusAlertDialog(
-                onDismissRequest = { showAddOtherWidget = false },
-                title = { Text(stringResource(R.string.settings_add_other_widget_title)) },
-                text = {
-                    Column {
-                        HomeExtraWidgetAddType.entries.forEach { type ->
-                            SettingsRow(
-                                    label = stringResource(type.labelRes),
-                                    subtitle =
-                                            stringResource(
-                                                    when (type) {
-                                                        HomeExtraWidgetAddType.WORLD_CLOCK ->
-                                                                R.string.settings_show_home_world_clock_subtitle
-                                                        HomeExtraWidgetAddType.COUNTDOWN ->
-                                                                R.string.settings_show_home_countdown_subtitle
-                                                    }
-                                            ),
-                                    horizontalPadding = 0.dp,
-                                    onClick = {
-                                        viewModel.addHomeExtraWidget(type)
-                                        showAddOtherWidget = false
-                                        when (type) {
-                                            HomeExtraWidgetAddType.WORLD_CLOCK ->
-                                                    pendingEditNewestCity = true
-                                            HomeExtraWidgetAddType.COUNTDOWN ->
-                                                    pendingEditNewestCountdown = true
-                                        }
-                                    },
-                            )
-                        }
-                    }
-                },
-                confirmButton = {},
-                dismissButton = {
-                    FokusTextButton(onClick = { showAddOtherWidget = false }) {
-                        Text(stringResource(R.string.action_cancel))
-                    }
-                },
-        )
-    }
-
-    // After adding a world clock, open the newest city for editing.
-    LaunchedEffect(uiState.worldClockCities, pendingEditNewestCity) {
-        if (pendingEditNewestCity) {
-            val newest = uiState.worldClockCities.maxByOrNull { it.position }
-            if (newest != null) {
-                editingCityId = newest.id
-                pendingEditNewestCity = false
-            }
-        }
-    }
-
-    LaunchedEffect(uiState.countdownEvents, pendingEditNewestCountdown) {
-        if (pendingEditNewestCountdown) {
-            val newest = uiState.countdownEvents.lastOrNull()
-            if (newest != null) {
-                editingCountdownId = newest.id
-                pendingEditNewestCountdown = false
-            }
-        }
-    }
-
-    editingCityId?.let { cityId ->
-        val city = citiesById[cityId]
-        if (city != null) {
-            WorldClockCityEditDialog(
-                    title = stringResource(R.string.settings_world_clock_edit_city),
-                    initialLabel = city.label,
-                    initialTimeZoneId = city.timeZoneId,
-                    onDismiss = { editingCityId = null },
-                    onSave = { label, zone ->
-                        if (viewModel.updateWorldClockCity(city.id, label, zone)) {
-                            editingCityId = null
-                        }
-                    },
-            )
-        }
-    }
-
-    editingCountdownId?.let { eventId ->
-        val event = eventsById[eventId]
-        if (event != null) {
-            CountdownEditDialog(
-                    initialTitle = event.title,
-                    initialEpochMillis = event.targetEpochMillis,
-                    onDismiss = { editingCountdownId = null },
-                    onSave = { title, epochMillis ->
-                        if (viewModel.saveCountdownEvent(event.id, title, epochMillis)) {
-                            editingCountdownId = null
-                        }
-                    },
-            )
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun DeviceControlSettingsScreen(
-        viewModel: SettingsViewModel = hiltViewModel(),
-        onNavigateBack: () -> Unit = {},
-        backgroundScrim: Color = FokusBackdrop.ScrimColorWithoutBlur
-) {
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val accessibilityDisclosureAccepted by viewModel.accessibilityProminentDisclosureAccepted.collectAsStateWithLifecycle()
-    val context = LocalContext.current
-    var showAccessibilityProminentDisclosure by remember { mutableStateOf(false) }
-    var accessibilityResumeTick by remember { mutableIntStateOf(0) }
-    val lifecycleOwner = LocalLifecycleOwner.current
-    OnResumeEffect(lifecycleOwner) { accessibilityResumeTick++ }
-
-    val lockAccessibilityOn =
-            remember(accessibilityResumeTick) {
-                LockScreenHelper.isLockAccessibilityServiceEnabled(context)
-            }
-
-    LaunchedEffect(lockAccessibilityOn, uiState.longLockReturnHome) {
-        if (uiState.longLockReturnHome && !lockAccessibilityOn) {
-            viewModel.setLongLockReturnHome(false)
-        }
-    }
-
-    val deviceControlToggleRows =
-            listOf(
-                    DeviceControlToggleRow(
-                            R.string.settings_double_tap_to_lock,
-                            stringResource(R.string.settings_double_tap_to_lock_subtitle),
-                            uiState.doubleTapEmptyLock,
-                            viewModel::setDoubleTapEmptyLock,
-                    ),
-                    DeviceControlToggleRow(
-                            R.string.settings_return_home_after_long_lock,
-                            stringResource(R.string.settings_return_home_after_long_lock_subtitle),
-                            uiState.longLockReturnHome,
-                            viewModel::setLongLockReturnHome,
-                    ),
-            )
-
-    Box(
-            modifier = Modifier
-                    .fillMaxSize()
-                    .background(backgroundScrim)
-                    .navigationBarsPadding()
-                    .testTag("device_control_settings_screen")
-    ) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            FokusSettingsTopBar(
-                    titleText = stringResource(R.string.settings_accessibility_page_title),
-                    onNavigateBack = onNavigateBack,
-                    containerColor = MaterialTheme.colorScheme.background,
-            )
-
-            LazyColumn(modifier = Modifier.weight(1f).fillMaxWidth()) {
-                item {
-                    SettingsToggleRow(
-                            label = stringResource(R.string.settings_accessibility_permission),
-                            subtitle =
-                                    stringResource(
-                                            if (lockAccessibilityOn) {
-                                                R.string.settings_accessibility_permission_enabled
-                                            } else {
-                                                R.string.settings_accessibility_permission_disabled
-                                            }
-                                    ),
-                            checked = lockAccessibilityOn,
-                            onCheckedChange = {
-                                when {
-                                    !lockAccessibilityOn && !accessibilityDisclosureAccepted ->
-                                            showAccessibilityProminentDisclosure = true
-                                    else ->
-                                            LockScreenHelper.openAccessibilitySettings(context)
-                                }
-                            }
-                    )
-                }
-
-                items(
-                        deviceControlToggleRows,
-                        key = { it.labelRes },
-                ) { row ->
-                    SettingsToggleRow(
-                            label = stringResource(row.labelRes),
-                            subtitle = row.subtitle,
-                            checked = row.checked,
-                            onCheckedChange = row.onCheckedChange,
-                            enabled = lockAccessibilityOn,
-                    )
-                }
-
-                if (lockAccessibilityOn && uiState.longLockReturnHome) {
-                    item {
-                        LongLockThresholdRow(
-                                currentMinutes = uiState.longLockReturnHomeThresholdMinutes,
-                                onMinutesSelected = viewModel::setLongLockReturnHomeThresholdMinutes
-                        )
-                    }
-                }
-            }
-        }
-
-        if (showAccessibilityProminentDisclosure) {
-            AccessibilityProminentDisclosureOverlay(
-                    onAccept = {
-                        showAccessibilityProminentDisclosure = false
-                        viewModel.acceptAccessibilityProminentDisclosureAndOpenSettings()
-                    },
-                    onNotNow = { showAccessibilityProminentDisclosure = false },
-            )
-        }
-    }
-}
-
-/**
- * Endonym: name of the language written in that language (e.g. English, Polski), independent of
- * app UI locale.
- */
-private fun languageAutonym(localeTag: String, allTags: List<String>): String {
-    val locale = Locale.forLanguageTag(localeTag)
-    val sameLanguageTags =
-            allTags.filter { Locale.forLanguageTag(it).language == locale.language }
-    val displayLocale =
-            when {
-                sameLanguageTags.size <= 1 -> locale
-                localeTag == "pt" -> Locale("pt", "PT")
-                else -> locale
-            }
-    val raw =
-            if (sameLanguageTags.size > 1) {
-                displayLocale.getDisplayName(displayLocale).trim()
-            } else {
-                locale.getDisplayLanguage(locale).trim()
-            }
-    if (raw.isBlank()) return localeTag
-    return raw.replaceFirstChar { ch ->
-        if (ch.isLowerCase()) ch.titlecase(displayLocale) else ch.toString()
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun HomeDateFormatDropdown(
-        currentStyle: HomeDateFormatStyle,
-        enabled: Boolean,
-        onStyleSelected: (HomeDateFormatStyle) -> Unit
-) {
-    val options = remember { HomeDateFormatStyle.entries }
-    var expanded by remember { mutableStateOf(false) }
-    val onDateFormatExpandedChange =
-            rememberBooleanChangeWithSystemSound { newExpanded ->
-                if (enabled) expanded = newExpanded
-            }
-    SettingsDropdown(
-            title = stringResource(R.string.settings_home_date_format),
-            options = options,
-            expanded = expanded,
-            onExpandedChange = onDateFormatExpandedChange,
-            selectedDisplayText = stringResource(currentStyle.labelRes),
-            fieldEnabled = enabled,
-            menuExpanded = expanded && enabled,
-            itemContent = { style ->
-                Text(
-                        text = stringResource(style.labelRes),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onBackground,
-                )
-            },
-            onItemSelected = onStyleSelected,
-    )
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun TemperatureUnitDropdown(
-        currentUnit: TemperatureUnit,
-        enabled: Boolean,
-        onUnitSelected: (TemperatureUnit) -> Unit
-) {
-    val options = remember { TemperatureUnit.entries }
-    var expanded by remember { mutableStateOf(false) }
-    val onExpandedChange =
-            rememberBooleanChangeWithSystemSound { newExpanded ->
-                if (enabled) expanded = newExpanded
-            }
-    SettingsDropdown(
-            title = stringResource(R.string.settings_temperature_unit),
-            options = options,
-            expanded = expanded,
-            onExpandedChange = onExpandedChange,
-            selectedDisplayText = stringResource(currentUnit.labelRes),
-            fieldEnabled = enabled,
-            menuExpanded = expanded && enabled,
-            itemContent = { unit ->
-                Text(
-                        text = stringResource(unit.labelRes),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onBackground,
-                )
-            },
-            onItemSelected = onUnitSelected,
-    )
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun NotificationIndicatorStyleDropdown(
-        currentStyle: NotificationIndicatorStyle,
-        onStyleSelected: (NotificationIndicatorStyle) -> Unit,
-) {
-    val options = remember { NotificationIndicatorStyle.entries }
-    var expanded by remember { mutableStateOf(false) }
-    val onExpandedChange = rememberBooleanChangeWithSystemSound { expanded = it }
-    SettingsDropdown(
-            title = stringResource(R.string.settings_notification_indicator_style),
-            options = options,
-            expanded = expanded,
-            onExpandedChange = onExpandedChange,
-            selectedDisplayText = stringResource(currentStyle.labelRes),
-            itemContent = { style ->
-                Text(
-                        text = stringResource(style.labelRes),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onBackground,
-                )
-            },
-            onItemSelected = onStyleSelected,
-    )
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun NotificationIndicatorColorDropdown(
-        currentColor: Int,
-        onColorSelected: (NotificationIndicatorColorPreset) -> Unit,
-) {
-    val options = remember { NotificationIndicatorColorPreset.entries }
-    val currentPreset = remember(currentColor) {
-        NotificationIndicatorColorPreset.fromArgb(currentColor)
-    }
-    var expanded by remember { mutableStateOf(false) }
-    val onExpandedChange = rememberBooleanChangeWithSystemSound { expanded = it }
-    SettingsDropdown(
-            title = stringResource(R.string.settings_notification_indicator_color),
-            options = options,
-            expanded = expanded,
-            onExpandedChange = onExpandedChange,
-            selectedDisplayText = stringResource(currentPreset.labelRes),
-            fieldTextColor = Color(currentPreset.argb),
-            menuItemTextColor = { Color(it.argb) },
-            itemContent = { preset ->
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Box(
-                            modifier =
-                                    Modifier.size(12.dp)
-                                            .background(Color(preset.argb), CircleShape),
-                    )
-                    Spacer(modifier = Modifier.width(12.dp))
-                    Text(
-                            text = stringResource(preset.labelRes),
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = Color(preset.argb),
-                    )
-                }
-            },
-            onItemSelected = onColorSelected,
-    )
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun AppLanguageDropdown(
-        currentTag: String,
-        onTagSelected: (String) -> Unit
-) {
-    val systemDefaultLabel = stringResource(R.string.settings_language_system_default)
-    val supportedLocaleTags =
-            remember {
-                listOf(
-                        "ca",
-                        "da",
-                        "de",
-                        "en",
-                        "es",
-                        "eu",
-                        "fi",
-                        "fr",
-                        "in",
-                        "it",
-                        "pl",
-                        "pt",
-                        "pt-BR",
-                        "ro",
-                        "ru",
-                        "ta",
-                        "tr",
-                        "uk",
-                        "zh-CN",
-                )
-            }
-    val options =
-            remember(systemDefaultLabel) {
-                val collator = Collator.getInstance(Locale.ROOT).apply { strength = Collator.PRIMARY }
-                buildList {
-                    add("" to systemDefaultLabel)
-                    supportedLocaleTags
-                            .map { tag -> tag to languageAutonym(tag, supportedLocaleTags) }
-                            .sortedWith { a, b -> collator.compare(a.second, b.second) }
-                            .forEach { add(it) }
-                }
-            }
-    var expanded by remember { mutableStateOf(false) }
-    val onLanguageExpandedChange = rememberBooleanChangeWithSystemSound { expanded = it }
-    val selectedDisplayText =
-            options.find { (tag, _) -> tag == currentTag }?.second
-                    ?: if (currentTag.isBlank()) {
-                        systemDefaultLabel
-                    } else {
-                        languageAutonym(currentTag, supportedLocaleTags)
-                    }
-    SettingsDropdown(
-            title = stringResource(R.string.settings_language_label),
-            options = options,
-            expanded = expanded,
-            onExpandedChange = onLanguageExpandedChange,
-            selectedDisplayText = selectedDisplayText,
-            itemContent = { (_, label) ->
-                Text(
-                        text = label,
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onBackground,
-                )
-            },
-            onItemSelected = { (storageTag, _) -> onTagSelected(storageTag) },
-    )
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun LauncherFontFamilyDropdown(
-        currentFamilyName: String,
-        installedFamilies: List<String>,
-        hasCustomFontFile: Boolean,
-        customFontDisplayName: String,
-        resolveCustomFontFile: (String) -> java.io.File?,
-        onFamilySelected: (String) -> Unit
-) {
-    val systemDefault = stringResource(R.string.settings_weather_app_system_default)
-    val customImportedFallback = stringResource(R.string.settings_font_custom_imported)
-    val customFontLabel =
-            customFontDisplayName.trim().ifBlank { customImportedFallback }
-    val options =
-            remember(
-                    currentFamilyName,
-                    installedFamilies,
-                    systemDefault,
-                    hasCustomFontFile,
-                    customFontLabel,
-            ) {
-                buildList {
-                    add("" to systemDefault)
-                    if (hasCustomFontFile) {
-                        add(LauncherFontPreferences.CUSTOM_FONT_STORAGE to customFontLabel)
-                    }
-                    val sorted = installedFamilies.sortedWith(String.CASE_INSENSITIVE_ORDER)
-                    sorted.forEach { add(it to it) }
-                    val cur = currentFamilyName.trim()
-                    if (cur.isNotEmpty() &&
-                                    sorted.none { it.equals(cur, ignoreCase = true) } &&
-                                    !(hasCustomFontFile &&
-                                            cur == LauncherFontPreferences.CUSTOM_FONT_STORAGE)
-                    ) {
-                        val label =
-                                if (LauncherFontPreferences.isCustomFont(cur)) {
-                                    customFontLabel
-                                } else {
-                                    cur
-                                }
-                        add(cur to label)
-                    }
-                }
-            }
-    var expanded by remember { mutableStateOf(false) }
-    val onFontExpandedChange = rememberBooleanChangeWithSystemSound { expanded = it }
-    val selectedLabel =
-            options.find { (value, _) -> value == currentFamilyName }?.second
-                    ?: currentFamilyName.ifBlank { systemDefault }
-    SettingsDropdown(
-            title = stringResource(R.string.settings_font_label),
-            options = options,
-            expanded = expanded,
-            onExpandedChange = onFontExpandedChange,
-            selectedDisplayText = selectedLabel,
-            textStyle =
-                    MaterialTheme.typography.bodyLarge.copy(
-                            fontFamily =
-                                    composeFontFamilyFromStoredName(currentFamilyName) {
-                                        resolveCustomFontFile(it)
-                                    }
-                    ),
-            itemContent = { (storageValue, label) ->
-                Text(
-                        text = label,
-                        style =
-                                MaterialTheme.typography.bodyLarge.copy(
-                                        fontFamily =
-                                                composeFontFamilyFromStoredName(storageValue) {
-                                                    resolveCustomFontFile(it)
-                                                }
-                                ),
-                        color = MaterialTheme.colorScheme.onBackground,
-                )
-            },
-            onItemSelected = { (storageValue, _) -> onFamilySelected(storageValue) },
-    )
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun LauncherFontSizeSlider(
-        currentScale: Float,
-        onScaleChange: (Float) -> Unit,
-) {
-    val synced = LauncherFontScale.snapToStep(currentScale)
-    var pending by remember { mutableFloatStateOf(synced) }
-    LaunchedEffect(synced) { pending = synced }
-
-    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 12.dp)) {
-        Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth(),
-        ) {
-            Text(
-                    text = stringResource(R.string.settings_font_size_label),
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onBackground,
-                    modifier = Modifier.weight(1f),
-            )
-            Text(
-                    text = String.format(Locale.US, "%.1fx", pending),
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.primary,
-            )
-        }
-        Spacer(Modifier.height(4.dp))
-        Text(
-                text = stringResource(R.string.settings_font_size_subtitle),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.secondary,
-        )
-        Spacer(Modifier.height(12.dp))
-        Slider(
-                value = pending,
-                onValueChange = { raw ->
-                    pending = LauncherFontScale.snapToStep(raw)
-                },
-                onValueChangeFinished = {
-                    val v = LauncherFontScale.snapToStep(pending)
-                    if (v != synced) {
-                        onScaleChange(v)
-                    }
-                },
-                valueRange = LauncherFontScale.MIN..LauncherFontScale.MAX,
-                steps = LauncherFontScale.SLIDER_STEPS,
-                modifier = Modifier.fillMaxWidth(),
-        )
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun PhotoWallpaperOutlineWidthSlider(
-        currentWidthDp: Float,
-        onWidthDpChange: (Float) -> Unit,
-) {
-    val synced = PhotoWallpaperOutlineWidthDp.snapToStep(currentWidthDp)
-    var pending by remember { mutableFloatStateOf(synced) }
-    LaunchedEffect(synced) { pending = synced }
-
-    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 12.dp)) {
-        Text(
-                text = stringResource(R.string.settings_photo_outline_strength_label),
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onBackground,
-        )
-        Spacer(Modifier.height(4.dp))
-        Text(
-                text = stringResource(R.string.settings_photo_outline_strength_subtitle),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.secondary,
-        )
-        Spacer(Modifier.height(12.dp))
-        Slider(
-                value = pending,
-                onValueChange = { raw ->
-                    pending = raw.coerceIn(PhotoWallpaperOutlineWidthDp.MIN, PhotoWallpaperOutlineWidthDp.MAX)
-                },
-                onValueChangeFinished = {
-                    val v = PhotoWallpaperOutlineWidthDp.snapToStep(pending)
-                    if (v != synced) {
-                        onWidthDpChange(v)
-                    }
-                },
-                valueRange = PhotoWallpaperOutlineWidthDp.MIN..PhotoWallpaperOutlineWidthDp.MAX,
-                steps = PhotoWallpaperOutlineWidthDp.SLIDER_STEPS,
-                modifier = Modifier.fillMaxWidth(),
-        )
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun PhotoWallpaperDrawerOverlaySlider(
-        currentIntensity: Float,
-        onIntensityChange: (Float) -> Unit,
-) {
-    val synced = PhotoWallpaperDrawerOverlayIntensity.snapToStep(currentIntensity)
-    var pending by remember { mutableFloatStateOf(synced) }
-    LaunchedEffect(synced) { pending = synced }
-
-    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 12.dp)) {
-        Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth(),
-        ) {
-            Text(
-                    text = stringResource(R.string.settings_photo_drawer_overlay_label),
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onBackground,
-                    modifier = Modifier.weight(1f),
-            )
-            Text(
-                    text = String.format(Locale.US, "%.1fx", pending),
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.primary,
-            )
-        }
-        Spacer(Modifier.height(4.dp))
-        Text(
-                text = stringResource(R.string.settings_photo_drawer_overlay_subtitle),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.secondary,
-        )
-        Spacer(Modifier.height(12.dp))
-        Slider(
-                value = pending,
-                onValueChange = { raw ->
-                    pending = PhotoWallpaperDrawerOverlayIntensity.snapToStep(raw)
-                },
-                onValueChangeFinished = {
-                    val v = PhotoWallpaperDrawerOverlayIntensity.snapToStep(pending)
-                    if (v != synced) {
-                        onIntensityChange(v)
-                    }
-                },
-                valueRange =
-                        PhotoWallpaperDrawerOverlayIntensity.MIN..PhotoWallpaperDrawerOverlayIntensity.MAX,
-                steps = PhotoWallpaperDrawerOverlayIntensity.SLIDER_STEPS,
-                modifier = Modifier.fillMaxWidth(),
-        )
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun LauncherVisualStyleDropdown(
-        currentStyle: LauncherVisualStyle,
-        onStyleSelected: (LauncherVisualStyle) -> Unit,
-        homeUsesPhotoWallpaper: Boolean,
-) {
-    val options = remember { LauncherVisualStyle.entries.toList() }
-    var expanded by remember { mutableStateOf(false) }
-    val onExpandedChange = rememberBooleanChangeWithSystemSound { expanded = it }
-    LaunchedEffect(homeUsesPhotoWallpaper) {
-        if (homeUsesPhotoWallpaper) expanded = false
-    }
-    val displayStyle =
-            if (homeUsesPhotoWallpaper) LauncherVisualStyle.CLASSIC else currentStyle
-    val selectedLabel = stringResource(displayStyle.labelRes)
-    val fieldPreviewColor = displayStyle.settingsPreviewColor()
-    val lockedSubtitle = stringResource(R.string.settings_look_locked_image_wallpaper)
-    val normalSubtitle = stringResource(R.string.settings_visual_style_subtitle)
-    val menuGlowEnabled = LocalLauncherIconGlow.current.enabled
-    val menuFontBlurBoost =
-            LocalLauncherFontScale.current.coerceIn(LauncherFontScale.MIN, LauncherFontScale.MAX)
-                    .coerceIn(0.85f, 1.45f)
-    SettingsDropdown(
-            title = stringResource(R.string.settings_visual_style_label),
-            subtitle = if (homeUsesPhotoWallpaper) lockedSubtitle else normalSubtitle,
-            options = options,
-            expanded = expanded,
-            onExpandedChange = onExpandedChange,
-            fieldEnabled = !homeUsesPhotoWallpaper,
-            selectedDisplayText = selectedLabel,
-            fieldTextColor = fieldPreviewColor,
-            menuItemTextColor = { it.settingsPreviewColor() },
-            itemContent = { style ->
-                val preview = style.settingsPreviewColor()
-                val itemTextStyle =
-                        if (menuGlowEnabled) {
-                            MaterialTheme.typography.bodyLarge.copy(
-                                    color = Color.Unspecified,
-                                    shadow =
-                                            Shadow(
-                                                    color = preview.copy(alpha = 1f),
-                                                    offset = Offset.Zero,
-                                                    blurRadius = 40f * menuFontBlurBoost,
-                                            ),
-                            )
-                        } else {
-                            MaterialTheme.typography.bodyLarge
-                                    .copy(color = Color.Unspecified)
-                                    .withoutLauncherTextGlow()
-                        }
-                Text(
-                        text = stringResource(style.labelRes),
-                        style = itemTextStyle,
-                        color = preview,
-                )
-            },
-            onItemSelected = onStyleSelected,
-    )
-}
-
-@Composable
-private fun SettingsLabeledSegmentedSection(
-        title: String,
-        subtitle: String?,
-        content: @Composable () -> Unit
-) {
-    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 12.dp)) {
-        Text(
-                text = title,
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onBackground
-        )
-        if (subtitle != null) {
-            Spacer(Modifier.height(4.dp))
-            Text(
-                    text = subtitle,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.secondary
-            )
-        }
-        Spacer(Modifier.height(12.dp))
-        content()
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun DrawerCategoryRailSideRow(
-        railOnLeft: Boolean,
-        onRailOnLeftChanged: (Boolean) -> Unit
-) {
-    SettingsLabeledSegmentedSection(
-            title = stringResource(R.string.settings_drawer_category_rail_side),
-            subtitle = stringResource(R.string.settings_drawer_category_rail_side_subtitle),
-    ) {
-        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-            SegmentedButton(
-                    selected = railOnLeft,
-                    onClick =
-                            rememberClickWithSystemSound { onRailOnLeftChanged(true) },
-                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
-                    icon = {},
-            ) {
-                Text(stringResource(R.string.settings_drawer_rail_position_left))
-            }
-            SegmentedButton(
-                    selected = !railOnLeft,
-                    onClick =
-                            rememberClickWithSystemSound { onRailOnLeftChanged(false) },
-                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
-                    icon = {},
-            ) {
-                Text(stringResource(R.string.settings_drawer_rail_position_right))
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun DrawerAppSortRow(
-        currentMode: DrawerAppSortMode,
-        showCustomSortOption: Boolean,
-        onModeChanged: (DrawerAppSortMode) -> Unit
-) {
-    val modes =
-            remember(showCustomSortOption) {
-                if (showCustomSortOption) DrawerAppSortMode.entries.toList()
-                else DrawerAppSortMode.entries.filterNot { it == DrawerAppSortMode.CUSTOM }
-            }
-    val coercedMode =
-            remember(currentMode, showCustomSortOption, modes) {
-                if (!showCustomSortOption && currentMode == DrawerAppSortMode.CUSTOM) {
-                    DrawerAppSortMode.ALPHABETICAL
-                } else {
-                    currentMode
-                }
-            }
-    SettingsLabeledSegmentedSection(
-            title = stringResource(R.string.settings_drawer_app_sort),
-            subtitle = stringResource(R.string.settings_drawer_app_sort_subtitle),
-    ) {
-        SingleChoiceSegmentedButtonRow(
-                modifier =
-                        Modifier.fillMaxWidth()
-                                .height(IntrinsicSize.Max)
-        ) {
-            modes.forEachIndexed { index, mode ->
-                SegmentedButton(
-                        selected = coercedMode == mode,
-                        onClick = rememberClickWithSystemSound { onModeChanged(mode) },
-                        modifier = Modifier.weight(1f).fillMaxHeight(),
-                        shape =
-                                SegmentedButtonDefaults.itemShape(
-                                        index = index,
-                                        count = modes.size
-                                ),
-                        icon = {},
-                ) {
-                    Box(
-                            modifier = Modifier.fillMaxWidth().fillMaxHeight(),
-                            contentAlignment = Alignment.Center,
-                    ) {
-                        Text(
-                                text = stringResource(mode.labelRes),
-                                maxLines = 2,
-                                overflow = TextOverflow.Ellipsis,
-                                textAlign = TextAlign.Center,
-                                modifier = Modifier.fillMaxWidth(),
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun LongLockThresholdRow(
-        currentMinutes: Int,
-        onMinutesSelected: (Int) -> Unit
-) {
-    val options = remember { listOf(1, 5, 15, 30) }
-    var expanded by remember { mutableStateOf(false) }
-    val onLongLockExpandedChange = rememberBooleanChangeWithSystemSound { expanded = it }
-    val selectedLabel =
-            pluralStringResource(
-                    R.plurals.settings_long_lock_duration_minutes,
-                    currentMinutes,
-                    currentMinutes
-            )
-    SettingsDropdown(
-            title = stringResource(R.string.settings_long_lock_duration),
-            subtitle = stringResource(R.string.settings_long_lock_duration_subtitle),
-            options = options,
-            expanded = expanded,
-            onExpandedChange = onLongLockExpandedChange,
-            selectedDisplayText = selectedLabel,
-            itemContent = { minutes ->
-                Text(
-                        text =
-                                pluralStringResource(
-                                        R.plurals.settings_long_lock_duration_minutes,
-                                        minutes,
-                                        minutes
-                                ),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onBackground
-                )
-            },
-            onItemSelected = onMinutesSelected,
-    )
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun HomeAlignmentRow(
-        currentAlignment: HomeAlignment,
-        onAlignmentChanged: (HomeAlignment) -> Unit
-) {
-    SettingsLabeledSegmentedSection(
-            title = stringResource(R.string.home_alignment_title),
-            subtitle = stringResource(R.string.home_alignment_subtitle),
-    ) {
-        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-            HomeAlignment.entries.forEachIndexed { index, alignment ->
-                SegmentedButton(
-                        selected = currentAlignment == alignment,
-                        onClick =
-                                rememberClickWithSystemSound {
-                                    onAlignmentChanged(alignment)
-                                },
-                        shape = SegmentedButtonDefaults.itemShape(
-                                index = index,
-                                count = HomeAlignment.entries.size
-                        ),
-                        icon = {},
-                ) {
-                    Text(stringResource(alignment.labelRes))
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun SubpageChevron() {
-    LauncherIcon(
-            imageVector = Icons.AutoMirrored.Filled.NavigateNext,
-            contentDescription = stringResource(R.string.cd_open_subpage),
-            tint = MaterialTheme.colorScheme.secondary,
-            iconSize = 22.dp,
-    )
-}
-
-@Composable
-private fun SectionHeader(title: String) {
-    Text(
-            text = title,
-            style =
-                    MaterialTheme.typography.labelLarge.copy(
-                            fontWeight = FontWeight.SemiBold,
-                            letterSpacing = 0.8.sp,
-                    ),
-            color = MaterialTheme.colorScheme.onBackground,
-            modifier = Modifier.padding(start = 24.dp, top = 20.dp, end = 24.dp, bottom = 8.dp),
-    )
-}
-
-@Composable
-private fun SettingsDivider() {
-    Spacer(Modifier.height(10.dp))
-    HorizontalDivider(
-            modifier = Modifier.padding(horizontal = 24.dp),
-            thickness = 0.75.dp,
-            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.16f)
-    )
-    Spacer(Modifier.height(10.dp))
-}
-
-@Composable
-private fun EmptySettingsStateText(text: String) {
-    Text(
-            text = text,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.secondary,
-            modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
-    )
-}
-
-@Composable
-private fun ExportLogsRow(
-        context: Context,
-        createLogShareIntent: suspend () -> Intent?
-) {
-    val scope = rememberCoroutineScope()
-    val activity = LocalActivity.current
-    val shareChooserTitle = stringResource(R.string.settings_export_logs_share_chooser)
-    val exportLogsFailedToast = stringResource(R.string.toast_export_logs_failed)
-    SettingsRow(
-            label = stringResource(R.string.settings_export_logs_title),
-            subtitle = stringResource(R.string.settings_export_logs_subtitle),
-            verticalPadding = 14.dp,
-            onClick = {
-                scope.launch {
-                    val shareIntent = createLogShareIntent()
-                    if (shareIntent != null && activity != null) {
-                        activity.startActivity(
-                                Intent.createChooser(shareIntent, shareChooserTitle)
-                        )
-                    } else {
-                        Toast.makeText(context, exportLogsFailedToast, Toast.LENGTH_SHORT).show()
-                    }
-                }
-            },
-    )
-}
-
-// --- Weather app (location gate + shortcut row) ---
-
-@Composable
-private fun WeatherAppSettingRow(
-        hasCoarseLocationPermission: Boolean,
-        onRequestLocationPermission: () -> Unit,
-        context: Context,
-        resources: Resources,
-        preferredWeatherTap: WidgetTapTarget?,
-        allApps: List<AppInfo>,
-        allShortcutActions: List<AppShortcutAction>,
-        onPickApp: () -> Unit,
-        onClear: () -> Unit,
-) {
-    Column {
-        if (!hasCoarseLocationPermission) {
-            SettingsRow(
-                    label = stringResource(R.string.settings_weather_location_disabled),
-                    subtitle = stringResource(R.string.settings_weather_location_disabled_subtitle),
-                    onClick = onRequestLocationPermission,
-                    leading = {
-                        LauncherIcon(
-                                imageVector = Icons.Outlined.LocationOn,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary,
-                                iconSize = 24.dp,
-                        )
-                    },
-                    trailing = {
-                        FokusTextButton(onClick = onRequestLocationPermission) {
-                            Text(stringResource(R.string.settings_weather_location_enable_button))
-                        }
-                    },
-            )
-        } else {
-            val weatherAppLabel =
-                    formatWidgetTapTarget(
-                            context = context,
-                            resources = resources,
-                            binding = preferredWeatherTap,
-                            allApps = allApps,
-                            allActions = allShortcutActions,
-                            emptyLabel = ::formatWeatherAppEmptyLabel,
-                    )
-            ShortcutTargetRow(
-                    label = stringResource(R.string.settings_weather_app),
-                    currentTarget = weatherAppLabel,
-                    onPickApp = onPickApp,
-                    onClear = onClear,
-            )
-        }
-    }
-}
-
-// --- Swipe shortcut row ---
-
-@Composable
-private fun ShortcutTargetRow(
-        label: String,
-        currentTarget: String,
-        onPickApp: () -> Unit,
-        onClear: () -> Unit
-) {
-    Row(
-            verticalAlignment = Alignment.Top,
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 12.dp)
-    ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                    label,
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onBackground
-            )
-            Text(
-                    currentTarget,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.secondary
-            )
-        }
-        Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(top = 2.dp),
-        ) {
-            FokusIconButton(
-                    onClick = onPickApp,
-                    modifier = Modifier.size(36.dp.launcherIconDp()),
-            ) {
-                LauncherIcon(
-                        Icons.Outlined.Edit,
-                        stringResource(R.string.action_change),
-                        tint = MaterialTheme.colorScheme.primary,
-                        iconSize = 20.dp,
-                )
-            }
-            FokusIconButton(
-                    onClick = onClear,
-                    modifier = Modifier.size(36.dp.launcherIconDp()),
-            ) {
-                LauncherIcon(
-                        Icons.Default.Close,
-                        stringResource(R.string.action_clear),
-                        tint = MaterialTheme.colorScheme.error,
-                        iconSize = 18.dp,
-                )
-            }
-        }
-    }
-}
-
-// =====================  DIALOGS  =====================
-
-private fun formatWidgetAppEmptyLabel(context: Context, resources: Resources): String =
-        resources.getString(R.string.settings_weather_app_system_default)
-
-private fun formatWeatherAppEmptyLabel(context: Context, resources: Resources): String {
-    val hasSystemWeatherApp =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                Intent(Intent.ACTION_MAIN)
-                        .apply { addCategory(Intent.CATEGORY_APP_WEATHER) }
-                        .resolveActivity(context.packageManager) != null
-            } else {
-                false
-            }
-    return if (hasSystemWeatherApp) {
-        resources.getString(R.string.settings_weather_app_system_default)
-    } else {
-        resources.getString(R.string.settings_weather_app_not_configured)
-    }
-}
-
-private fun formatWidgetTapTarget(
-        context: Context,
-        resources: Resources,
-        binding: WidgetTapTarget?,
-        allApps: List<AppInfo>,
-        allActions: List<AppShortcutAction>,
-        emptyLabel: (Context, Resources) -> String,
-): String {
-    if (binding == null) return emptyLabel(context, resources)
-    val resolvedLabel =
-            allActions.find {
-                it.target == binding.target && it.profileKey == binding.profileKey
-            }?.actionLabel
-    return formatShortcutTargetDisplay(
-            context = context,
-            target = binding.target,
-            allApps = allApps,
-            notSetLabel = emptyLabel(context, resources),
-            resolvedLauncherActionLabel = resolvedLabel,
-            profileKey = binding.profileKey,
-    )
-}
-
-private fun formatShortcutTarget(
-        context: Context,
-        resources: Resources,
-        target: ShortcutTarget?,
-        allApps: List<AppInfo>
-): String {
-    return formatShortcutTargetDisplay(
-            context = context,
-            target = target,
-            allApps = allApps,
-            notSetLabel = resources.getString(R.string.shortcut_target_not_set),
-            resolvedLauncherActionLabel = null
-    )
 }

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/components/SettingsComponents.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/settings/components/SettingsComponents.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.NavigateNext
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -30,10 +31,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.lu4p.fokuslauncher.R
 import com.lu4p.fokuslauncher.data.model.LauncherFontScale
 import com.lu4p.fokuslauncher.ui.components.LauncherIcon
 import com.lu4p.fokuslauncher.ui.theme.LocalLauncherFontScale
@@ -372,4 +377,38 @@ fun SettingsDivider() {
             color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.16f),
     )
     Spacer(Modifier.height(10.dp))
+}
+
+@Composable
+internal fun SectionHeader(title: String) {
+    Text(
+            text = title,
+            style =
+                    MaterialTheme.typography.labelLarge.copy(
+                            fontWeight = FontWeight.SemiBold,
+                            letterSpacing = 0.8.sp,
+                    ),
+            color = MaterialTheme.colorScheme.onBackground,
+            modifier = Modifier.padding(start = 24.dp, top = 20.dp, end = 24.dp, bottom = 8.dp),
+    )
+}
+
+@Composable
+internal fun SubpageChevron() {
+    LauncherIcon(
+            imageVector = Icons.AutoMirrored.Filled.NavigateNext,
+            contentDescription = stringResource(R.string.cd_open_subpage),
+            tint = MaterialTheme.colorScheme.secondary,
+            iconSize = 22.dp,
+    )
+}
+
+@Composable
+internal fun EmptySettingsStateText(text: String) {
+    Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.secondary,
+            modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
+    )
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,6 +158,17 @@
 
     <!-- Settings -->
     <string name="settings_title">Settings</string>
+    <string name="settings_look_and_feel_title">Look &amp; feel</string>
+    <string name="settings_look_and_feel_subtitle">Language, fonts, colors, glow, wallpaper, and notification indicators</string>
+    <string name="settings_drawer_behavior_title">Drawer behavior</string>
+    <string name="settings_drawer_behavior_subtitle">Sidebar, app order, auto launch, and search keyboard</string>
+    <string name="settings_section_apps">Apps</string>
+    <string name="settings_apps_management_title">Hidden, renamed &amp; archived</string>
+    <string name="settings_apps_management_subtitle_empty">No managed apps yet</string>
+    <plurals name="settings_apps_management_count">
+        <item quantity="one">%d managed app</item>
+        <item quantity="other">%d managed apps</item>
+    </plurals>
     <string name="settings_section_appearance">Appearance</string>
     <string name="settings_show_status_bar">Show status bar</string>
     <string name="settings_allow_landscape_rotation">Allow landscape</string>


### PR DESCRIPTION
## Summary

- Split settings into dedicated screens for appearance, app management, device control, drawer behavior, and home widgets.
- Simplify navigation and shared settings controls.
- Regenerate the shipped outlined icon set and update localized strings.

## Testing

- Not run.