### PR TITLE
Fix refresh race when loading favorite apps

### DIFF
--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeViewModel.kt
@@ -486,13 +486,16 @@ class HomeViewModel @Inject constructor(
         }
         val apps = appRepository.getInstalledApps()
         val archivedApps = appRepository.getArchivedApps()
+        // Read DataStore directly: refresh runs on Dispatchers.IO and can race ahead of
+        // rawFavorites' Main-thread stateIn collector during ViewModel init.
+        val currentFavorites = preferencesManager.favoritesFlow.first()
         if (apps.isEmpty()) {
             if (archivedApps.isNotEmpty()) {
                 applyInstalledAppsSnapshot(apps)
                 return false
             }
             if (_allInstalledApps.value.isNotEmpty() ||
-                            rawFavorites.value.any { !it.isPhoneFavoriteSentinel() }
+                            currentFavorites.any { !it.isPhoneFavoriteSentinel() }
             ) {
                 return false
             }
@@ -502,7 +505,6 @@ class HomeViewModel @Inject constructor(
         applyInstalledAppsSnapshot(apps)
         val installedAppKeys = apps.map { appMetadataKey(it) }.toSet()
         val archivedAppKeys = _archivedAppKeys.value
-        val currentFavorites = rawFavorites.value
         val nonSentinel = currentFavorites.filterNot { it.isPhoneFavoriteSentinel() }
         val missingFavoriteKeys =
                 nonSentinel

--- a/app/src/test/java/com/lu4p/fokuslauncher/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/lu4p/fokuslauncher/ui/home/HomeViewModelTest.kt
@@ -801,7 +801,8 @@ class HomeViewModelTest {
         viewModel.refreshInstalledApps()
         testDispatcher.scheduler.advanceUntilIdle()
 
-        coVerify {
+        // refreshInstalledApps launches on Dispatchers.IO; wait for the prune write.
+        coVerify(timeout = 2_000) {
             preferencesManager.setFavorites(
                 match { favorites ->
                     favorites.size == 1 &&


### PR DESCRIPTION
## Summary
- Read favorites directly from DataStore during app refresh to avoid stale `stateIn` values.
- Prevent valid favorites from being pruned during ViewModel initialization races.
- Make the refresh test wait for the asynchronous prune write.

## Testing
- Updated `HomeViewModelTest` with a timeout for the asynchronous favorites update.