### PR TITLE
Launch the launcher activity shown in the app list instead of the package launch intent

### DIFF
--- a/app/src/main/java/com/lu4p/fokuslauncher/data/repository/AppRepository.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/repository/AppRepository.kt
@@ -678,6 +678,12 @@ constructor(
      * @return true if the app was launched successfully, false otherwise.
      */
     fun launchApp(packageName: String, options: Bundle? = null): Boolean {
+        // Launch the activity the app list shows. PackageManager.getLaunchIntentForPackage picks
+        // its own winner among a package's MAIN/INFO activities, so packages exposing several
+        // (e.g. vendor Settings with an emergency entry) could open a different screen.
+        mainLauncherActivity(packageName)?.let { component ->
+            if (launchMainActivity(component, Process.myUserHandle(), options)) return true
+        }
         val intent = context.packageManager.getLaunchIntentForPackage(packageName)
         return if (intent != null) {
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
@@ -687,6 +693,17 @@ constructor(
             false
         }
     }
+
+    /** First owner-profile launcher activity of [packageName], matching how the app list is built. */
+    private fun mainLauncherActivity(packageName: String): ComponentName? =
+            try {
+                launcherAppsOrNull()
+                        ?.getActivityList(packageName, Process.myUserHandle())
+                        ?.firstOrNull()
+                        ?.componentName
+            } catch (_: Exception) {
+                null
+            }
 
     /**
      * Launches a web-style search in the given app or via the system resolver. [target] null uses

--- a/app/src/test/java/com/lu4p/fokuslauncher/data/repository/AppRepositoryTest.kt
+++ b/app/src/test/java/com/lu4p/fokuslauncher/data/repository/AppRepositoryTest.kt
@@ -435,6 +435,32 @@ class AppRepositoryTest {
     }
 
     @Test
+    fun `launchApp starts the launcher activity the app list shows`() {
+        val settingsComponent = ComponentName("com.android.settings", "com.android.settings.Settings")
+        every { launcherApps.getActivityList("com.android.settings", myUser) } returns
+                listOf(
+                        createMockLauncherActivity(
+                                "com.android.settings",
+                                "Settings",
+                                activityName = settingsComponent.className,
+                        ),
+                        createMockLauncherActivity(
+                                "com.android.settings",
+                                "Emergency rescue",
+                                activityName = "com.android.settings.EmergencyRescue",
+                        ),
+                )
+        every { packageManager.getLaunchIntentForPackage("com.android.settings") } returns
+                mockk<Intent>(relaxed = true)
+
+        val result = repository.launchApp("com.android.settings")
+
+        assertTrue(result)
+        verify { launcherApps.startMainActivity(settingsComponent, myUser, null, null) }
+        verify(exactly = 0) { context.startActivity(any<Intent>(), any()) }
+    }
+
+    @Test
     fun `launchApp returns false when no intent found`() {
         val realContext = RuntimeEnvironment.getApplication().applicationContext as Context
         val realRepository = AppRepository(realContext, appDao, PrivateSpaceManager(realContext))
@@ -963,6 +989,7 @@ class AppRepositoryTest {
             category: Int = ApplicationInfo.CATEGORY_UNDEFINED,
             flags: Int = 0,
             archived: Boolean = false,
+            activityName: String = "$packageName.MainActivity",
     ): android.content.pm.LauncherActivityInfo {
         val mockLa = mockk<android.content.pm.LauncherActivityInfo>(relaxed = true)
         val appInfo =
@@ -974,8 +1001,7 @@ class AppRepositoryTest {
                 }
         every { mockLa.applicationInfo } returns appInfo
         every { mockLa.label } returns label
-        every { mockLa.componentName } returns
-                ComponentName(packageName, "$packageName.MainActivity")
+        every { mockLa.componentName } returns ComponentName(packageName, activityName)
         every { mockLa.getBadgedIcon(0) } returns null
         return mockLa
     }


### PR DESCRIPTION
# Launch the launcher activity shown in the app list instead of the package launch intent

## Problem

Tapping an app can open a different screen than the one the tile is labelled with. On a CUBOT KingKong Mini 4 (Android 15), tapping Settings opens the vendor's Emergency Rescue page.

## Cause

Owner profile entries drop their component name when the app list is built, so the launch falls back to `PackageManager.getLaunchIntentForPackage`. That API resolves `MAIN` + `CATEGORY_INFO` first and only then `CATEGORY_LAUNCHER`, while the app list comes from `LauncherApps.getActivityList`, which is `CATEGORY_LAUNCHER` only. A package exposing both can be labelled from one activity and launched into another.

On this ROM `com.android.settings` ships `com.hxy.emergency.SettingsActivity` as `MAIN` + `CATEGORY_INFO`, so it wins over `com.android.settings/.Settings` and Settings never opens. Not device specific: any ROM with a `CATEGORY_INFO` activity inside a drawer package hits the same path.

## Fix

`launchApp` resolves the same activity the app list shows and starts it with `LauncherApps.startMainActivity`. `getLaunchIntentForPackage` stays as the fallback for packages `LauncherApps` cannot resolve.

## Tests

New unit test in `AppRepositoryTest`: a package with two launcher activities must start the first one through `startMainActivity` and must not fall back to `startActivity`. Fails on master. Full `:app:testDebugUnitTest` suite green.

Checked on device, same phone and state, only the build differs: master resumes `com.android.settings/com.hxy.emergency.SettingsActivity`, this branch resumes `com.android.settings/.Settings`.
