### PR TITLE
Keep PWA names separate from the browser they were installed from

### DIFF
--- a/app/src/main/java/com/lu4p/fokuslauncher/data/model/AppInfo.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/model/AppInfo.kt
@@ -92,12 +92,13 @@ fun overlayCustomName(
     val packageRows =
             renamedApps.filter { it.packageName == app.packageName && it.profileKey == profileKey }
     if (packageRows.isEmpty()) return null
+    // Names are per row: renaming the host browser must not rename the PWAs it published.
     app.launcherShortcutId?.let { shortcutId ->
-        packageRows.find { it.launcherShortcutId == shortcutId }?.customName?.let { return it }
+        return packageRows.find { it.launcherShortcutId == shortcutId }?.customName
     }
-            ?: packageRows.find { it.launcherShortcutId == HOST_APP_METADATA_SENTINEL }?.customName?.let {
-                return it
-            }
+    packageRows.find { it.launcherShortcutId == HOST_APP_METADATA_SENTINEL }?.customName?.let {
+        return it
+    }
     return packageRows.find { it.launcherShortcutId == LEGACY_PACKAGE_WIDE_METADATA }?.customName
 }
 

--- a/app/src/main/java/com/lu4p/fokuslauncher/data/model/FavoriteApp.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/data/model/FavoriteApp.kt
@@ -32,14 +32,20 @@ data class FavoriteApp(
         get() = (resolvedIconTarget as? ShortcutTarget.App)?.packageName ?: packageName
 }
 
-fun favoriteAppStableKey(favorite: FavoriteApp): String {
-    val base = drawerOpenCountKey(favorite.packageName, favorite.profileKey)
+/** Pinned launcher shortcut (PWA) this favorite points at, or null for a plain app row. */
+fun favoriteLauncherShortcutId(favorite: FavoriteApp): String? {
     val target = favorite.resolvedIconTarget
     return if (target is ShortcutTarget.LauncherShortcut &&
                     target.packageName == favorite.packageName
     ) {
-        "$base#shortcut:${target.shortcutId}"
+        target.shortcutId
     } else {
-        base
+        null
     }
+}
+
+fun favoriteAppStableKey(favorite: FavoriteApp): String {
+    val base = drawerOpenCountKey(favorite.packageName, favorite.profileKey)
+    val shortcutId = favoriteLauncherShortcutId(favorite) ?: return base
+    return "$base#shortcut:$shortcutId"
 }

--- a/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/lu4p/fokuslauncher/ui/home/HomeViewModel.kt
@@ -29,6 +29,7 @@ import com.lu4p.fokuslauncher.data.model.appMetadataKey
 import com.lu4p.fokuslauncher.data.model.appProfileKey
 import com.lu4p.fokuslauncher.data.model.drawerOpenCountKey
 import com.lu4p.fokuslauncher.data.model.favoriteAppStableKey
+import com.lu4p.fokuslauncher.data.model.favoriteLauncherShortcutId
 import com.lu4p.fokuslauncher.data.model.HOST_APP_METADATA_SENTINEL
 import com.lu4p.fokuslauncher.data.model.metadataSettingsStableKey
 import com.lu4p.fokuslauncher.data.model.CountdownEvent
@@ -704,6 +705,10 @@ class HomeViewModel @Inject constructor(
         return rawRightSideShortcuts.value.filterNot { shortcutArchivedKey(it) in archivedKeys }
     }
 
+    /** Metadata row a favorite owns: its own shortcut row for PWAs, else the host app row. */
+    private fun favoriteMetadataShortcutId(favorite: FavoriteApp): String =
+            favoriteLauncherShortcutId(favorite) ?: HOST_APP_METADATA_SENTINEL
+
     private fun resolveFavoritesSnapshot(
             favs: List<FavoriteApp>,
             renames: Map<String, String>,
@@ -712,11 +717,17 @@ class HomeViewModel @Inject constructor(
     ): List<FavoriteApp> =
             favs.filterNot { favoriteAppStableKey(it) in archivedKeys }.map { fav ->
                 val appKey = favoriteAppStableKey(fav)
+                // PWA rows only answer to their own key; the package-wide keys belong to the
+                // host app and would show the browser name on every PWA.
+                val hostKey =
+                        appMetadataKey(fav.packageName, fav.profileKey).takeIf {
+                            favoriteLauncherShortcutId(fav) == null
+                        }
                 val resolvedName =
                         renames[appKey]
-                                ?: renames[appMetadataKey(fav.packageName, fav.profileKey)]
+                                ?: hostKey?.let { renames[it] }
                                 ?: appNames[appKey]
-                                ?: appNames[appMetadataKey(fav.packageName, fav.profileKey)]
+                                ?: hostKey?.let { appNames[it] }
                                 ?: fav.label
                 fav.copy(label = resolvedName)
             }
@@ -871,7 +882,12 @@ class HomeViewModel @Inject constructor(
                     preferencesManager.setFavorites(current)
                 }
             } else {
-                appRepository.renameApp(favorite.packageName, favorite.profileKey, newName)
+                appRepository.renameApp(
+                        favorite.packageName,
+                        favorite.profileKey,
+                        newName,
+                        favoriteMetadataShortcutId(favorite),
+                )
             }
             dismissAppMenu()
         }
@@ -896,15 +912,10 @@ class HomeViewModel @Inject constructor(
     fun hideApp(favorite: FavoriteApp) {
         if (endAppMenuIfPhoneFavoriteSentinel(favorite)) return
         viewModelScope.launch {
-            val launcherShortcutId =
-                    when (val target = favorite.resolvedIconTarget) {
-                        is ShortcutTarget.LauncherShortcut -> target.shortcutId
-                        else -> HOST_APP_METADATA_SENTINEL
-                    }
             appRepository.hideApp(
                     favorite.packageName,
                     favorite.profileKey,
-                    launcherShortcutId,
+                    favoriteMetadataShortcutId(favorite),
             )
             val current = rawFavorites.value.toMutableList()
             val favoriteKey = favoriteAppStableKey(favorite)

--- a/app/src/test/java/com/lu4p/fokuslauncher/data/model/AppInfoMetadataTest.kt
+++ b/app/src/test/java/com/lu4p/fokuslauncher/data/model/AppInfoMetadataTest.kt
@@ -1,6 +1,7 @@
 package com.lu4p.fokuslauncher.data.model
 
 import com.lu4p.fokuslauncher.data.database.entity.AppCategoryEntity
+import com.lu4p.fokuslauncher.data.database.entity.RenamedAppEntity
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
@@ -35,6 +36,43 @@ class AppInfoMetadataTest {
                     icon = null,
                     launcherShortcutId = shortcutId,
             )
+
+    @Test
+    fun `overlayCustomName never renames PWAs after the host browser`() {
+        val renames =
+                listOf(
+                        RenamedAppEntity(
+                                browserPackage,
+                                "0",
+                                "Vivaldi",
+                                launcherShortcutId = HOST_APP_METADATA_SENTINEL,
+                        ),
+                        RenamedAppEntity(
+                                browserPackage,
+                                "0",
+                                "Vivaldi",
+                                launcherShortcutId = LEGACY_PACKAGE_WIDE_METADATA,
+                        ),
+                )
+
+        assertEquals("Vivaldi", overlayCustomName(browserHost(), renames))
+        assertNull(overlayCustomName(pwa("pwa-twitter", "Twitter"), renames))
+    }
+
+    @Test
+    fun `overlayCustomName uses the per-PWA rename`() {
+        val renames =
+                listOf(
+                        RenamedAppEntity(
+                                browserPackage,
+                                "0",
+                                "Bird",
+                                launcherShortcutId = "pwa-twitter",
+                        ),
+                )
+
+        assertEquals("Bird", overlayCustomName(pwa("pwa-twitter", "Twitter"), renames))
+    }
 
     @Test
     fun `overlayCategory uses per-PWA assignment when present`() {

--- a/app/src/test/java/com/lu4p/fokuslauncher/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/lu4p/fokuslauncher/ui/home/HomeViewModelTest.kt
@@ -777,6 +777,68 @@ class HomeViewModelTest {
         )
     }
 
+    private fun pwaFavorite(
+            label: String = "Twitter",
+            packageName: String = "org.mozilla.firefox",
+            shortcutId: String = "pwa-twitter",
+    ) =
+            FavoriteApp(
+                    label = label,
+                    packageName = packageName,
+                    iconPackage =
+                            ShortcutTarget.encode(
+                                    ShortcutTarget.LauncherShortcut(packageName, shortcutId)
+                            ),
+                    profileKey = "0",
+            )
+
+    @Test
+    fun `renameApp on a PWA favorite writes the per-shortcut row`() {
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.renameApp(pwaFavorite(), "Bird")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify {
+            appRepository.renameApp("org.mozilla.firefox", "0", "Bird", "pwa-twitter")
+        }
+    }
+
+    @Test
+    fun `favorites keep the PWA name when the host browser is renamed`() {
+        val favorite = pwaFavorite()
+        every { preferencesManager.favoritesFlow } returns flowOf(listOf(favorite))
+        every { appRepository.getAllRenamedApps() } returns
+                flowOf(
+                        listOf(
+                                com.lu4p.fokuslauncher.data.database.entity.RenamedAppEntity(
+                                        packageName = "org.mozilla.firefox",
+                                        profileKey = "0",
+                                        customName = "Firefox Beta",
+                                        launcherShortcutId = HOST_APP_METADATA_SENTINEL,
+                                )
+                        )
+                )
+        every { appRepository.getInstalledApps() } returns
+                listOf(
+                        AppInfo("org.mozilla.firefox", "Firefox", null),
+                        AppInfo(
+                                packageName = "org.mozilla.firefox",
+                                label = "Twitter",
+                                icon = null,
+                                launcherShortcutId = "pwa-twitter",
+                        ),
+                )
+
+        val viewModel = createViewModel()
+        val collectJob = CoroutineScope(testDispatcher).launch { viewModel.favorites.collect { } }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("Twitter", viewModel.favorites.value.single().label)
+        collectJob.cancel()
+    }
+
     @Test
     fun `removeFavoriteFromEdit removes built-in phone favorite without installed app`() {
         val phoneFavorite =


### PR DESCRIPTION
# Keep PWA names separate from the browser they were installed from

## Problem

Every PWA published by a browser shows the browser's name, so the browser and all of its PWAs become identical rows in the drawer and on the home screen. Same symptom as #123, different path: the trigger here is renaming the browser.

Steps: install two PWAs from Brave (Brave creates pinned shortcuts, it does not mint WebAPKs), rename the browser, and both PWA rows take the new name. The platform data is fine, `dumpsys shortcut` still reports the right `shortLabel` for each shortcut. The name is lost in the metadata overlay.

## Cause

Three places treat a PWA row as if it were the host app:

1. `overlayCustomName` falls through to the host row and then to the legacy package wide row when a shortcut has no rename of its own, so renaming the browser renames its PWAs. `isAppHiddenByMetadata` already scopes host rows correctly, naming did not.
2. `HomeViewModel.renameApp` omitted the shortcut id, so renaming a PWA favorite wrote to the browser's row instead. `hideApp` right below it already did this correctly.
3. `resolveFavoritesSnapshot` fell back to the package wide keys for shortcut favorites, so the leak also reached the home screen.

Category inheritance in `overlayCategory` is host wide on purpose and covered by existing tests, so it is left alone. Only names are scoped per row.

## Fix

A PWA row resolves its name from its own metadata row only, favorite renames write the row the favorite owns, and home favorites no longer fall back to package wide keys for shortcut rows.

## Tests

Four unit tests in `AppInfoMetadataTest` and `HomeViewModelTest`, all failing on master: host and legacy rows must not reach a shortcut row, the per shortcut rename still applies, renaming a PWA favorite writes the per shortcut row, and a PWA favorite keeps its name when the browser is renamed. Full `:app:testDebugUnitTest` suite green.

Checked on device with Brave, a pinned shortcut and the browser renamed: master shows two rows with the browser's new name, this branch keeps the shortcut's own name.
